### PR TITLE
DTR-5534: Corrected Utr value for ChRIS submission

### DIFF
--- a/app/services/submission/ChrisSubmissionRequestBuilder.scala
+++ b/app/services/submission/ChrisSubmissionRequestBuilder.scala
@@ -16,65 +16,59 @@
 
 package services.submission
 
-import connectors.ConstructionIndustrySchemeConnector
 import models.ReturnType.*
-import models.{ReturnType, UserAnswers}
-import models.monthlyreturns.CisTaxpayer
-import models.requests.GetMonthlyReturnForEditRequest
+import models.monthlyreturns.{CisTaxpayer, GetAllMonthlyReturnDetailsResponse}
 import models.submission.*
+import models.{ReturnType, UserAnswers}
 import pages.monthlyreturns.*
-import pages.amend.AmendmentDetailsPage
-import uk.gov.hmrc.http.HeaderCarrier
 import utils.Normalise.yesNo
 
 import java.time.YearMonth
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
 
-class ChrisSubmissionRequestBuilder @Inject() (
-  cisConnector: ConstructionIndustrySchemeConnector
-)(implicit ec: ExecutionContext) {
+class ChrisSubmissionRequestBuilder @Inject() {
 
-  def build(ua: UserAnswers, taxpayer: CisTaxpayer, isAgent: Boolean)(implicit
-    hc: HeaderCarrier
-  ): Future[ChrisSubmissionRequest] = {
+  def build(
+    ua: UserAnswers,
+    taxpayer: CisTaxpayer,
+    isAgent: Boolean,
+    monthlyReturn: GetAllMonthlyReturnDetailsResponse
+  ): ChrisSubmissionRequest = {
     val returnType         = ua.get(ReturnTypePage).getOrElse(throw new RuntimeException("ReturnType missing"))
-    val common             = buildCommon(ua, taxpayer, isAgent)
+    val common             = buildCommon(ua, taxpayer, isAgent, monthlyReturn)
     val informationCorrect = true
     val inactivityBool     = ua.get(SubmitInactivityRequestPage).contains(true)
 
     returnType match {
       case MonthlyNilReturn | MonthlyAmendedNilReturn =>
-        Future.successful(
-          ChrisSubmissionRequest.fromNil(
-            common = common,
-            informationCorrect = informationCorrect,
-            inactivity = inactivityBool
-          )
+        ChrisSubmissionRequest.fromNil(
+          common = common,
+          informationCorrect = informationCorrect,
+          inactivity = inactivityBool
         )
 
       case MonthlyStandardReturn | MonthlyAmendedStandardReturn =>
-        buildStandardMonthlyReturn(ua).map { standardReturn =>
-          ChrisSubmissionRequest.fromStandard(
-            common = common,
-            informationCorrect = informationCorrect,
-            inactivity = inactivityBool,
-            standard = standardReturn
-          )
-        }
+        ChrisSubmissionRequest.fromStandard(
+          common = common,
+          informationCorrect = informationCorrect,
+          inactivity = inactivityBool,
+          standard = buildStandardMonthlyReturn(ua, monthlyReturn)
+        )
     }
   }
 
   private def buildCommon(
     ua: UserAnswers,
     taxpayer: CisTaxpayer,
-    isAgent: Boolean
+    isAgent: Boolean,
+    monthlyReturn: GetAllMonthlyReturnDetailsResponse
   ): ChrisSubmissionCommon = {
 
-    val utr = taxpayer.utr
+    val schemeUtr = monthlyReturn.scheme.headOption
+      .flatMap(_.utr)
       .map(_.trim)
       .filter(_.nonEmpty)
-      .getOrElse(throw new RuntimeException("CIS taxpayer UTR missing"))
+      .getOrElse(throw new RuntimeException("Scheme UTR missing"))
 
     val aoDistrict = taxpayer.aoDistrict
       .map(_.trim)
@@ -108,7 +102,7 @@ class ChrisSubmissionRequestBuilder @Inject() (
     val emailOpt = ua.get(EnterYourEmailAddressPage)
 
     ChrisSubmissionCommon(
-      utr = utr,
+      utr = schemeUtr,
       aoReference = accountsOfficeRef,
       monthYear = ym,
       email = emailOpt,
@@ -119,8 +113,9 @@ class ChrisSubmissionRequestBuilder @Inject() (
   }
 
   private def buildStandardMonthlyReturn(
-    ua: UserAnswers
-  )(implicit hc: HeaderCarrier): Future[ChrisStandardMonthlyReturn] = {
+    ua: UserAnswers,
+    monthlyReturn: GetAllMonthlyReturnDetailsResponse
+  ): ChrisStandardMonthlyReturn = {
     val employmentStatus: String = ua
       .get(EmploymentStatusDeclarationPage)
       .map(yesNo)
@@ -136,21 +131,7 @@ class ChrisSubmissionRequestBuilder @Inject() (
       verification = verification
     )
 
-    val requiredAnswers = for {
-      cisId      <- ua.get(CisIdPage)
-      taxDate    <- ua.get(DateConfirmPaymentsPage)
-      isAmendment = ua.get(AmendmentDetailsPage).isDefined
-    } yield (cisId, taxDate.getMonthValue, taxDate.getYear, isAmendment)
-
-    requiredAnswers.fold(
-      Future.failed(RuntimeException("Could not build CHRIS request due to missing user answers"))
-    ) { (cisId, taxMonth, taxYear, isAmendment) =>
-      cisConnector
-        .retrieveMonthlyReturnForEditDetails(GetMonthlyReturnForEditRequest(cisId, taxMonth, taxYear, isAmendment))
-        .map { details =>
-          val subcontractors = StandardReturnSubcontractorsBuilder.build(ua, details.subcontractors)
-          ChrisStandardMonthlyReturn(subcontractors, declarations)
-        }
-    }
+    val subcontractors = StandardReturnSubcontractorsBuilder.build(ua, monthlyReturn.subcontractors)
+    ChrisStandardMonthlyReturn(subcontractors, declarations)
   }
 }

--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -81,12 +81,27 @@ class SubmissionService @Inject() (
       else
         cisConnector.getCisTaxpayer()
 
+    val requiredAnswers = for {
+      cisId      <- ua.get(CisIdPage)
+      taxDate    <- ua.get(DateConfirmPaymentsPage)
+      isAmendment = ua.get(AmendmentDetailsPage).isDefined
+    } yield (cisId, taxDate.getMonthValue, taxDate.getYear, isAmendment)
+
     for {
-      taxpayer  <- taxpayerFut
-      csr       <- chrisRequestBuilder.build(ua, taxpayer, isAgent)(hc)
-      response  <- cisConnector.submitToChris(submissionId, csr)
-      amendment <- fetchAmendmentFlag(ua)
-      _         <- writeToFeMongo(ua, submissionId, response, amendment)
+      taxpayer                                <- taxpayerFut
+      (cisId, taxMonth, taxYear, isAmendment) <-
+        requiredAnswers.fold(
+          Future.failed[(String, Int, Int, Boolean)](
+            new RuntimeException("Required user answers missing")
+          )
+        )(Future.successful)
+      monthlyReturn                           <- cisConnector.retrieveMonthlyReturnForEditDetails(
+                                                   GetMonthlyReturnForEditRequest(cisId, taxMonth, taxYear, isAmendment)
+                                                 )
+      csr                                      = chrisRequestBuilder.build(ua, taxpayer, isAgent, monthlyReturn)
+      response                                <- cisConnector.submitToChris(submissionId, csr)
+      amendment                                = monthlyReturn.monthlyReturn.headOption.flatMap(_.amendment)
+      _                                       <- writeToFeMongo(ua, submissionId, response, amendment)
     } yield response
 
   def updateSubmissionFromChrisResponse(
@@ -325,21 +340,6 @@ class SubmissionService @Inject() (
     Try(Instant.parse(timestamp))
       .orElse(Try(LocalDateTime.parse(timestamp).atZone(ZoneOffset.UTC).toInstant))
       .toOption
-
-  private def fetchAmendmentFlag(ua: UserAnswers)(implicit hc: HeaderCarrier): Future[Option[String]] = {
-    val instanceId  = ua.get(CisIdPage).getOrElse(throw new RuntimeException("CIS ID missing"))
-    val ym          = selectedYearMonth(ua)
-    val isAmendment = ua.get(AmendmentDetailsPage).isDefined
-    cisConnector
-      .retrieveMonthlyReturnForEditDetails(
-        GetMonthlyReturnForEditRequest(instanceId, ym.getMonthValue, ym.getYear, isAmendment)
-      )
-      .map(_.monthlyReturn.headOption.flatMap(_.amendment))
-      .recover { case ex =>
-        logger.warn("[fetchAmendmentFlag] Failed to retrieve amendment flag, defaulting to None", ex)
-        None
-      }
-  }
 
   private def writeToFeMongo(
     ua: UserAnswers,

--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -92,7 +92,7 @@ class SubmissionService @Inject() (
       (cisId, taxMonth, taxYear, isAmendment) <-
         requiredAnswers.fold(
           Future.failed[(String, Int, Int, Boolean)](
-            new RuntimeException("Required user answers missing")
+            new RuntimeException("Month and year of return missing")
           )
         )(Future.successful)
       monthlyReturn                           <- cisConnector.retrieveMonthlyReturnForEditDetails(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "13.7.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "13.8.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % hmrcMongoVersion
   )

--- a/test/services/submission/ChrisSubmissionRequestBuilderSpec.scala
+++ b/test/services/submission/ChrisSubmissionRequestBuilderSpec.scala
@@ -16,25 +16,20 @@
 
 package services.submission
 
-import connectors.ConstructionIndustrySchemeConnector
 import models.ReturnType.{MonthlyNilReturn, MonthlyStandardReturn}
-import models.{ReturnType, UserAnswers}
 import models.monthlyreturns.*
-import models.requests.GetMonthlyReturnForEditRequest
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.TryValues.*
-import org.mockito.Mockito.*
-import org.mockito.ArgumentMatchers.{any, eq as eqTo}
+import models.{ReturnType, UserAnswers}
 import org.scalatest.TryValues
+import org.scalatest.TryValues.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import pages.monthlyreturns.*
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.{LocalDate, LocalDateTime}
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Failure
+import scala.concurrent.ExecutionContext
 
 class ChrisSubmissionRequestBuilderSpec
     extends AnyWordSpec
@@ -106,11 +101,29 @@ class ChrisSubmissionRequestBuilderSpec
       displayName = Some("A B")
     )
 
+  private val subId: Long = 1L
+
+  private val monthlyReturn = GetAllMonthlyReturnDetailsResponse(
+    scheme = Seq(
+      ContractorScheme(
+        schemeId = 1,
+        instanceId = "CIS-123",
+        accountsOfficeReference = "123PA12345678",
+        taxOfficeNumber = "123",
+        taxOfficeReference = "AB456",
+        utr = Some("3111111125")
+      )
+    ),
+    monthlyReturn = Seq.empty,
+    subcontractors = Seq(mkSubcontractor(subId)),
+    monthlyReturnItems = Seq.empty,
+    submission = Seq.empty
+  )
+
   "ChrisSubmissionRequestBuilder.build" should {
 
     "build MonthlyNilReturn request (minimal)" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val ua =
         UserAnswers("id")
@@ -127,33 +140,25 @@ class ChrisSubmissionRequestBuilderSpec
           .success
           .value
 
-      val reqF = builder.build(ua, mkTaxpayer(), isAgent = false)
+      val req = builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
 
-      whenReady(reqF) { req =>
-        req.returnType mustBe MonthlyNilReturn
-        req.standard mustBe None
+      req.returnType mustBe MonthlyNilReturn
+      req.standard mustBe None
 
-        req.utr mustBe "1234567890"
-        req.aoReference mustBe "754PT000002240"
-        req.monthYear mustBe "2025-09"
-        req.email mustBe Some("test@test.com")
+      req.utr mustBe "3111111125"
+      req.aoReference mustBe "754PT000002240"
+      req.monthYear mustBe "2025-09"
+      req.email mustBe Some("test@test.com")
 
-        req.informationCorrect mustBe "yes"
-        req.inactivity mustBe "yes"
-        req.isAgent mustBe false
-        req.clientTaxOfficeNumber mustBe "123"
-        req.clientTaxOfficeRef mustBe "AB456"
-      }
-
-      verify(connector, times(0))
-        .retrieveMonthlyReturnForEditDetails(any[GetMonthlyReturnForEditRequest])(any[HeaderCarrier])
+      req.informationCorrect mustBe "yes"
+      req.inactivity mustBe "yes"
+      req.isAgent mustBe false
+      req.clientTaxOfficeNumber mustBe "123"
+      req.clientTaxOfficeRef mustBe "AB456"
     }
 
     "build MonthlyStandardReturn request" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
-
-      val subId: Long = 1L
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val ua =
         UserAnswers("id")
@@ -191,55 +196,33 @@ class ChrisSubmissionRequestBuilderSpec
           .success
           .value
 
-      val details = GetAllMonthlyReturnDetailsResponse(
-        scheme = Seq.empty,
-        monthlyReturn = Seq.empty,
-        subcontractors = Seq(mkSubcontractor(subId)),
-        monthlyReturnItems = Seq.empty,
-        submission = Seq.empty
-      )
+      val req = builder.build(ua, mkTaxpayer(), isAgent = true, monthlyReturn)
 
-      when(
-        connector.retrieveMonthlyReturnForEditDetails(
-          eqTo(GetMonthlyReturnForEditRequest("instance-1", 9, 2025, false))
-        )(any[HeaderCarrier])
-      )
-        .thenReturn(Future.successful(details))
-
-      val reqF = builder.build(ua, mkTaxpayer(), isAgent = true)
-
-      whenReady(reqF) { req =>
-        req.returnType mustBe MonthlyStandardReturn
-        req.standard.isDefined mustBe true
-        req.informationCorrect mustBe "yes"
-        req.inactivity mustBe "no"
-        req.isAgent mustBe true
-      }
-
-      verify(connector, times(1))
-        .retrieveMonthlyReturnForEditDetails(eqTo(GetMonthlyReturnForEditRequest("instance-1", 9, 2025, false)))(
-          any[HeaderCarrier]
-        )
+      req.returnType mustBe MonthlyStandardReturn
+      req.standard.isDefined mustBe true
+      req.informationCorrect mustBe "yes"
+      req.inactivity mustBe "no"
+      req.isAgent mustBe true
     }
 
     "fail when ReturnTypePage missing" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val ua = UserAnswers("id")
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, mkTaxpayer(), isAgent = false)
+        builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "ReturnType missing"
     }
 
-    "fail when taxpayer UTR is missing" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+    "fail when Scheme UTR is missing" in {
+      val builder = new ChrisSubmissionRequestBuilder()
 
-      val taxpayer = mkTaxpayer().copy(utr = None)
+      val updatedMonthlyReturn = monthlyReturn.copy(
+        scheme = monthlyReturn.scheme.map(_.copy(utr = None))
+      )
 
       val ua =
         UserAnswers("id")
@@ -251,15 +234,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, taxpayer, isAgent = false)
+        builder.build(ua, mkTaxpayer(), isAgent = false, updatedMonthlyReturn)
       }
 
-      ex.getMessage mustBe "CIS taxpayer UTR missing"
+      ex.getMessage mustBe "Scheme UTR missing"
     }
 
     "fail when taxpayer aoDistrict is missing" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val taxpayer = mkTaxpayer().copy(aoDistrict = None)
 
@@ -273,15 +255,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, taxpayer, isAgent = false)
+        builder.build(ua, taxpayer, isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "CIS taxpayer aoDistrict missing"
     }
 
     "fail when taxpayer aoPayType is missing" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val taxpayer = mkTaxpayer().copy(aoPayType = None)
 
@@ -295,15 +276,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, taxpayer, isAgent = false)
+        builder.build(ua, taxpayer, isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "CIS taxpayer aoPayType missing"
     }
 
     "fail when taxpayer aoCheckCode is missing" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val taxpayer = mkTaxpayer().copy(aoCheckCode = None)
 
@@ -317,15 +297,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, taxpayer, isAgent = false)
+        builder.build(ua, taxpayer, isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "CIS taxpayer aoCheckCode missing"
     }
 
     "fail when taxpayer aoReference is missing" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val taxpayer = mkTaxpayer().copy(aoReference = None)
 
@@ -339,15 +318,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, taxpayer, isAgent = false)
+        builder.build(ua, taxpayer, isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "CIS taxpayer aoReference missing"
     }
 
     "fail when month and year of return are missing for nil return" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val ua =
         UserAnswers("id")
@@ -356,15 +334,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, mkTaxpayer(), isAgent = false)
+        builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "Month and year of return missing"
     }
 
     "fail when month and year of return are missing for standard return" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val ua =
         UserAnswers("id")
@@ -373,15 +350,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, mkTaxpayer(), isAgent = false)
+        builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "Month and year of return missing"
     }
 
     "fail when employment status declaration is missing for standard return" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val ua =
         UserAnswers("id")
@@ -399,15 +375,14 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, mkTaxpayer(), isAgent = false)
+        builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "Employment status declaration missing"
     }
 
     "fail when verification answer is missing for standard return" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
+      val builder = new ChrisSubmissionRequestBuilder()
 
       val ua =
         UserAnswers("id")
@@ -425,34 +400,33 @@ class ChrisSubmissionRequestBuilderSpec
           .value
 
       val ex = intercept[RuntimeException] {
-        builder.build(ua, mkTaxpayer(), isAgent = false)
+        builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
       }
 
       ex.getMessage mustBe "Verification answer missing"
     }
 
-    "fail when CIS ID is missing for standard return" in {
-      val connector = mock[ConstructionIndustrySchemeConnector]
-      val builder   = new ChrisSubmissionRequestBuilder(connector)
-
-      val ua =
-        UserAnswers("id")
-          .set(ReturnTypePage, ReturnType.MonthlyStandardReturn)
-          .success
-          .value
-          .set(DateConfirmPaymentsPage, LocalDate.of(2025, 9, 1))
-          .success
-          .value
-          .set(EmploymentStatusDeclarationPage, true)
-          .success
-          .value
-          .set(VerifiedStatusDeclarationPage, true)
-          .success
-          .value
-
-      val result = builder.build(ua, mkTaxpayer(), isAgent = false)
-
-      result.value mustBe a[Some[Failure[RuntimeException]]]
-    }
+//    "fail when CIS ID is missing for standard return" in {
+//      val builder = new ChrisSubmissionRequestBuilder()
+//
+//      val ua =
+//        UserAnswers("id")
+//          .set(ReturnTypePage, ReturnType.MonthlyStandardReturn)
+//          .success
+//          .value
+//          .set(DateConfirmPaymentsPage, LocalDate.of(2025, 9, 1))
+//          .success
+//          .value
+//          .set(EmploymentStatusDeclarationPage, true)
+//          .success
+//          .value
+//          .set(VerifiedStatusDeclarationPage, true)
+//          .success
+//          .value
+//
+//      val result = builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
+//
+//      result.value mustBe a[Some[Failure[RuntimeException]]]
+//    }
   }
 }

--- a/test/services/submission/ChrisSubmissionRequestBuilderSpec.scala
+++ b/test/services/submission/ChrisSubmissionRequestBuilderSpec.scala
@@ -405,28 +405,5 @@ class ChrisSubmissionRequestBuilderSpec
 
       ex.getMessage mustBe "Verification answer missing"
     }
-
-//    "fail when CIS ID is missing for standard return" in {
-//      val builder = new ChrisSubmissionRequestBuilder()
-//
-//      val ua =
-//        UserAnswers("id")
-//          .set(ReturnTypePage, ReturnType.MonthlyStandardReturn)
-//          .success
-//          .value
-//          .set(DateConfirmPaymentsPage, LocalDate.of(2025, 9, 1))
-//          .success
-//          .value
-//          .set(EmploymentStatusDeclarationPage, true)
-//          .success
-//          .value
-//          .set(VerifiedStatusDeclarationPage, true)
-//          .success
-//          .value
-//
-//      val result = builder.build(ua, mkTaxpayer(), isAgent = false, monthlyReturn)
-//
-//      result.value mustBe a[Some[Failure[RuntimeException]]]
-//    }
   }
 }

--- a/test/services/submission/SubmissionServiceSpec.scala
+++ b/test/services/submission/SubmissionServiceSpec.scala
@@ -250,8 +250,14 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
           .thenReturn(Future.successful(taxpayer))
 
         val builtCsr = mock(classOf[ChrisSubmissionRequest])
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(false))(any[HeaderCarrier]))
-          .thenReturn(Future.successful(builtCsr))
+        when(
+          chrisRequestBuilder.build(
+            any[UserAnswers],
+            any[CisTaxpayer],
+            eqTo(false),
+            any[GetAllMonthlyReturnDetailsResponse]
+          )
+        ).thenReturn(builtCsr)
 
         val beResp = mkChrisResp()
 
@@ -286,13 +292,49 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
         when(connector.getCisTaxpayer()(any[HeaderCarrier]))
           .thenReturn(Future.successful(taxpayer))
 
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(false))(any[HeaderCarrier]))
-          .thenReturn(Future.failed(new RuntimeException("boom-builder")))
+        val monthlyReturnResponse = GetAllMonthlyReturnDetailsResponse(
+          scheme = Seq.empty,
+          monthlyReturn = Seq.empty,
+          subcontractors = Seq.empty,
+          monthlyReturnItems = Seq.empty,
+          submission = Seq.empty
+        )
+
+        when(connector.retrieveMonthlyReturnForEditDetails(any[GetMonthlyReturnForEditRequest])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(monthlyReturnResponse))
+
+        when(
+          chrisRequestBuilder
+            .build(any[UserAnswers], any[CisTaxpayer], eqTo(false), any[GetAllMonthlyReturnDetailsResponse])
+        ).thenThrow(new RuntimeException("boom-builder"))
 
         val ex = intercept[RuntimeException] {
           service.submitToChrisAndPersist("sub-123", uaBase, false).futureValue
         }
         ex.getMessage must include("boom-builder")
+
+        verify(connector, never()).submitToChris(any[String], any[ChrisSubmissionRequest])(any[HeaderCarrier])
+        verify(sessionRepository, never()).set(any[UserAnswers])
+      }
+
+      "fail when user answers missing for monthlyReturnForEdit api call" in {
+        val connector: ConstructionIndustrySchemeConnector = mock(classOf[ConstructionIndustrySchemeConnector])
+        val sessionRepository: SessionRepository           = mock(classOf[SessionRepository])
+        val appConfig: FrontendAppConfig                   = new FrontendAppConfig(
+          Configuration(
+            "submission-poll-timeout-seconds" -> "60"
+          )
+        )
+        val chrisRequestBuilder                            = mock(classOf[ChrisSubmissionRequestBuilder])
+        val service                                        = mkService(connector, sessionRepository, appConfig, chrisRequestBuilder)
+
+        when(connector.getCisTaxpayer()(any[HeaderCarrier]))
+          .thenReturn(Future.successful(taxpayer))
+
+        val ex = intercept[RuntimeException] {
+          service.submitToChrisAndPersist("sub-123", emptyUserAnswers, false).futureValue
+        }
+        ex.getMessage must include("Required user answers missing")
 
         verify(connector, never()).submitToChris(any[String], any[ChrisSubmissionRequest])(any[HeaderCarrier])
         verify(sessionRepository, never()).set(any[UserAnswers])
@@ -339,8 +381,11 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
           .thenReturn(Future.successful(beRespWithEndpoint))
 
         val builtCsr = mock(classOf[ChrisSubmissionRequest])
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(false))(any[HeaderCarrier]))
-          .thenReturn(Future.successful(builtCsr))
+        when(
+          chrisRequestBuilder
+            .build(any[UserAnswers], any[CisTaxpayer], eqTo(false), any[GetAllMonthlyReturnDetailsResponse])
+        )
+          .thenReturn(builtCsr)
 
         val out = service.submitToChrisAndPersist("sub-123", uaWithInactivityYes, false).futureValue
         out mustBe beRespWithEndpoint
@@ -365,8 +410,11 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
           .thenReturn(Future.successful(taxpayer))
 
         val builtCsr = mock(classOf[ChrisSubmissionRequest])
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(false))(any[HeaderCarrier]))
-          .thenReturn(Future.successful(builtCsr))
+        when(
+          chrisRequestBuilder
+            .build(any[UserAnswers], any[CisTaxpayer], eqTo(false), any[GetAllMonthlyReturnDetailsResponse])
+        )
+          .thenReturn(builtCsr)
         when(connector.submitToChris(eqTo("sub-123"), any[ChrisSubmissionRequest])(any[HeaderCarrier]))
           .thenReturn(Future.successful(mkChrisResp()))
 
@@ -402,8 +450,11 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
           .thenReturn(Future.successful(taxpayer))
 
         val builtCsr = mock(classOf[ChrisSubmissionRequest])
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(false))(any[HeaderCarrier]))
-          .thenReturn(Future.successful(builtCsr))
+        when(
+          chrisRequestBuilder
+            .build(any[UserAnswers], any[CisTaxpayer], eqTo(false), any[GetAllMonthlyReturnDetailsResponse])
+        )
+          .thenReturn(builtCsr)
         when(connector.submitToChris(eqTo("sub-123"), any[ChrisSubmissionRequest])(any[HeaderCarrier]))
           .thenReturn(Future.successful(mkChrisResp()))
 
@@ -416,36 +467,6 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
         )
         when(connector.retrieveMonthlyReturnForEditDetails(any[GetMonthlyReturnForEditRequest])(any[HeaderCarrier]))
           .thenReturn(Future.successful(emptyResponse))
-
-        val uaCaptor: ArgumentCaptor[UserAnswers] = ArgumentCaptor.forClass(classOf[UserAnswers])
-        when(sessionRepository.set(uaCaptor.capture())).thenReturn(Future.successful(true))
-
-        service.submitToChrisAndPersist("sub-123", uaWithInactivityYes, false).futureValue
-
-        val saved = uaCaptor.getValue
-        saved.get(SubmissionDetailsPage).value.amendment mustBe None
-      }
-
-      "default amendment flag to None when retrieveMonthlyReturnForEditDetails fails" in {
-        val connector: ConstructionIndustrySchemeConnector = mock(classOf[ConstructionIndustrySchemeConnector])
-        val sessionRepository: SessionRepository           = mock(classOf[SessionRepository])
-        val appConfig: FrontendAppConfig                   = new FrontendAppConfig(
-          Configuration("submission-poll-timeout-seconds" -> "60")
-        )
-        val chrisRequestBuilder                            = mock(classOf[ChrisSubmissionRequestBuilder])
-        val service                                        = new SubmissionService(connector, appConfig, sessionRepository, chrisRequestBuilder, utcClock)
-
-        when(connector.getCisTaxpayer()(any[HeaderCarrier]))
-          .thenReturn(Future.successful(taxpayer))
-
-        val builtCsr = mock(classOf[ChrisSubmissionRequest])
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(false))(any[HeaderCarrier]))
-          .thenReturn(Future.successful(builtCsr))
-        when(connector.submitToChris(eqTo("sub-123"), any[ChrisSubmissionRequest])(any[HeaderCarrier]))
-          .thenReturn(Future.successful(mkChrisResp()))
-
-        when(connector.retrieveMonthlyReturnForEditDetails(any[GetMonthlyReturnForEditRequest])(any[HeaderCarrier]))
-          .thenReturn(Future.failed(new RuntimeException("BE unavailable")))
 
         val uaCaptor: ArgumentCaptor[UserAnswers] = ArgumentCaptor.forClass(classOf[UserAnswers])
         when(sessionRepository.set(uaCaptor.capture())).thenReturn(Future.successful(true))
@@ -471,8 +492,11 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
           .thenReturn(Future.successful(taxpayer))
 
         val builtCsr = mock(classOf[ChrisSubmissionRequest])
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(false))(any[HeaderCarrier]))
-          .thenReturn(Future.successful(builtCsr))
+        when(
+          chrisRequestBuilder
+            .build(any[UserAnswers], any[CisTaxpayer], eqTo(false), any[GetAllMonthlyReturnDetailsResponse])
+        )
+          .thenReturn(builtCsr)
 
         val beResp = mkChrisResp()
 
@@ -514,8 +538,11 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
           .thenReturn(Future.successful(taxpayer))
 
         val builtCsr = mock(classOf[ChrisSubmissionRequest])
-        when(chrisRequestBuilder.build(any[UserAnswers], any[CisTaxpayer], eqTo(true))(any[HeaderCarrier]))
-          .thenReturn(Future.successful(builtCsr))
+        when(
+          chrisRequestBuilder
+            .build(any[UserAnswers], any[CisTaxpayer], eqTo(true), any[GetAllMonthlyReturnDetailsResponse])
+        )
+          .thenReturn(builtCsr)
 
         val beResp = mkChrisResp()
 

--- a/test/services/submission/SubmissionServiceSpec.scala
+++ b/test/services/submission/SubmissionServiceSpec.scala
@@ -334,7 +334,7 @@ class SubmissionServiceSpec extends SpecBase with TryValues {
         val ex = intercept[RuntimeException] {
           service.submitToChrisAndPersist("sub-123", emptyUserAnswers, false).futureValue
         }
-        ex.getMessage must include("Required user answers missing")
+        ex.getMessage must include("Month and year of return missing")
 
         verify(connector, never()).submitToChris(any[String], any[ChrisSubmissionRequest])(any[HeaderCarrier])
         verify(sessionRepository, never()).set(any[UserAnswers])


### PR DESCRIPTION
The UTR used for CHRIS submissions was previously being read from the CIS_KF table via the getCisTaxpayer endpoint. This was incorrect, as the UTR should be sourced from the SCHEME table.

This change updates the implementation to retrieve the UTR from the SCHEME table by calling the monthlyReturnForEdit endpoint and using the UTR returned in the scheme data.

Additionally, removed redundant monthlyReturnForEdit endpoint calls.