### PR TITLE
DTR-6575: [Bug] Fix for Incorrect duplicate submission message

### DIFF
--- a/app/controllers/monthlyreturns/CheckYourAnswersController.scala
+++ b/app/controllers/monthlyreturns/CheckYourAnswersController.scala
@@ -145,14 +145,15 @@ class CheckYourAnswersController @Inject() (
   }
 
   private def guardCompletedJourney(block: => Future[Result])(implicit request: CisIdDataRequest[_]): Future[Result] =
-    val periodEnd       = required(
-      periodEndFromUserAnswers(request.userAnswers),
-      "[SubmissionSuccess] taxPeriodEnd missing from userAnswers"
-    )
-    val yearMonthPeriod = YearMonth.from(periodEnd).toString
-    if (request.userAnswers.get(SubmissionJourneyCompletedPage(yearMonthPeriod)).contains(true)) {
-      Future.successful(Redirect(controllers.monthlyreturns.routes.AlreadySubmittedController.onPageLoad()))
-    } else {
-      block
+    periodEndFromUserAnswers(request.userAnswers) match {
+      case None            =>
+        Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+      case Some(periodEnd) =>
+        val yearMonthPeriod = YearMonth.from(periodEnd).toString
+        if (request.userAnswers.get(SubmissionJourneyCompletedPage(yearMonthPeriod)).contains(true)) {
+          Future.successful(Redirect(controllers.monthlyreturns.routes.AlreadySubmittedController.onPageLoad()))
+        } else {
+          block
+        }
     }
 }

--- a/app/controllers/monthlyreturns/CheckYourAnswersController.scala
+++ b/app/controllers/monthlyreturns/CheckYourAnswersController.scala
@@ -17,6 +17,7 @@
 package controllers.monthlyreturns
 
 import controllers.actions.*
+import controllers.helpers.SubmissionViewDataSupport
 import models.ReturnType
 import models.monthlyreturns.UpdateMonthlyReturnRequest
 import models.requests.CisIdDataRequest
@@ -33,6 +34,7 @@ import viewmodels.govuk.summarylist.*
 import views.html.monthlyreturns.CheckYourAnswersView
 import utils.UserAnswerUtils.isJourneyComplete
 
+import java.time.YearMonth
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -49,7 +51,8 @@ class CheckYourAnswersController @Inject() (
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport
-    with Logging {
+    with Logging
+    with SubmissionViewDataSupport {
 
   def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData andThen requireCisId).async {
     implicit request =>
@@ -142,7 +145,12 @@ class CheckYourAnswersController @Inject() (
   }
 
   private def guardCompletedJourney(block: => Future[Result])(implicit request: CisIdDataRequest[_]): Future[Result] =
-    if (request.userAnswers.get(SubmissionJourneyCompletedPage).contains(true)) {
+    val periodEnd       = required(
+      periodEndFromUserAnswers(request.userAnswers),
+      "[SubmissionSuccess] taxPeriodEnd missing from userAnswers"
+    )
+    val yearMonthPeriod = YearMonth.from(periodEnd).toString
+    if (request.userAnswers.get(SubmissionJourneyCompletedPage(yearMonthPeriod)).contains(true)) {
       Future.successful(Redirect(controllers.monthlyreturns.routes.AlreadySubmittedController.onPageLoad()))
     } else {
       block

--- a/app/controllers/monthlyreturns/SubmissionSendingController.scala
+++ b/app/controllers/monthlyreturns/SubmissionSendingController.scala
@@ -17,6 +17,7 @@
 package controllers.monthlyreturns
 
 import controllers.actions.*
+import controllers.helpers.SubmissionViewDataSupport
 import models.UserAnswers
 import models.requests.CisIdDataRequest
 import models.submission.PollDecision.{Polled, Skip}
@@ -33,6 +34,7 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import utils.UserAnswerUtils.isJourneyComplete
 import views.html.monthlyreturns.SubmissionSendingView
 
+import java.time.YearMonth
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -48,7 +50,8 @@ class SubmissionSendingController @Inject() (
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport
-    with Logging {
+    with Logging
+    with SubmissionViewDataSupport {
 
   def onPageLoad: Action[AnyContent] =
     (identify andThen getData andThen requireData andThen requireCisId).async { implicit request =>
@@ -108,7 +111,12 @@ class SubmissionSendingController @Inject() (
     }
 
   private def guardCompletedJourney(block: => Future[Result])(implicit request: CisIdDataRequest[_]): Future[Result] =
-    if (request.userAnswers.get(SubmissionJourneyCompletedPage).contains(true)) {
+    val periodEnd       = required(
+      periodEndFromUserAnswers(request.userAnswers),
+      "[SubmissionSuccess] taxPeriodEnd missing from userAnswers"
+    )
+    val yearMonthPeriod = YearMonth.from(periodEnd).toString
+    if (request.userAnswers.get(SubmissionJourneyCompletedPage(yearMonthPeriod)).contains(true)) {
       Future.successful(Redirect(controllers.monthlyreturns.routes.AlreadySubmittedController.onPageLoad()))
     } else {
       block

--- a/app/controllers/monthlyreturns/SubmissionSendingController.scala
+++ b/app/controllers/monthlyreturns/SubmissionSendingController.scala
@@ -111,15 +111,16 @@ class SubmissionSendingController @Inject() (
     }
 
   private def guardCompletedJourney(block: => Future[Result])(implicit request: CisIdDataRequest[_]): Future[Result] =
-    val periodEnd       = required(
-      periodEndFromUserAnswers(request.userAnswers),
-      "[SubmissionSuccess] taxPeriodEnd missing from userAnswers"
-    )
-    val yearMonthPeriod = YearMonth.from(periodEnd).toString
-    if (request.userAnswers.get(SubmissionJourneyCompletedPage(yearMonthPeriod)).contains(true)) {
-      Future.successful(Redirect(controllers.monthlyreturns.routes.AlreadySubmittedController.onPageLoad()))
-    } else {
-      block
+    periodEndFromUserAnswers(request.userAnswers) match {
+      case None            =>
+        Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+      case Some(periodEnd) =>
+        val yearMonthPeriod = YearMonth.from(periodEnd).toString
+        if (request.userAnswers.get(SubmissionJourneyCompletedPage(yearMonthPeriod)).contains(true)) {
+          Future.successful(Redirect(controllers.monthlyreturns.routes.AlreadySubmittedController.onPageLoad()))
+        } else {
+          block
+        }
     }
 
   private def pollDecisionResult(decision: PollDecision, pollInterval: String)(implicit

--- a/app/pages/submission/SubmissionJourneyCompletedPage.scala
+++ b/app/pages/submission/SubmissionJourneyCompletedPage.scala
@@ -19,9 +19,9 @@ package pages.submission
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object SubmissionJourneyCompletedPage extends QuestionPage[Boolean] {
+case class SubmissionJourneyCompletedPage(period: String) extends QuestionPage[Boolean] {
 
-  override def path: JsPath = JsPath \ "submissionJourneyCompleted"
+  override def path: JsPath = JsPath \ "submissionJourneyCompleted" \ period \ "completed"
 
   override def toString: String = "submissionJourneyCompleted"
 }

--- a/app/services/MonthlyReturnService.scala
+++ b/app/services/MonthlyReturnService.scala
@@ -36,7 +36,7 @@ import utils.UserAnswerUtils.clearMonthlyReturnJourney
 import utils.Utils.toBigDecimal
 import viewmodels.SelectSubcontractorsViewModel
 
-import java.time.LocalDate
+import java.time.{LocalDate, YearMonth}
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -196,10 +196,19 @@ class MonthlyReturnService @Inject() (
 
   def completeSubmissionJourney(userAnswers: UserAnswers)(implicit hc: HeaderCarrier): Future[Unit] = {
     val updatedTry =
-      for {
-        withCompleted <- userAnswers.set(SubmissionJourneyCompletedPage, true)
-        cleared       <- withCompleted.clearMonthlyReturnJourney
-      } yield cleared
+      userAnswers.get(DateConfirmPaymentsPage) match {
+        case Some(periodEnd) =>
+          for {
+            withCompleted <- userAnswers.set(
+                               SubmissionJourneyCompletedPage(YearMonth.from(periodEnd).toString),
+                               true
+                             )
+            cleared       <- withCompleted.clearMonthlyReturnJourney
+          } yield cleared
+
+        case None =>
+          scala.util.Failure(new RuntimeException("dateConfirmPayments missing"))
+      }
 
     updatedTry match {
       case scala.util.Success(updatedAnswers) => sessionRepository.set(updatedAnswers).map(_ => ())

--- a/app/utils/UserAnswerUtils.scala
+++ b/app/utils/UserAnswerUtils.scala
@@ -76,6 +76,7 @@ object UserAnswerUtils {
         .flatMap(_.remove(ResubmissionIdPage))
 
         // monthly nil return
+        .flatMap(_.remove(NilReturnStatusPage))
         .flatMap(_.remove(ConfirmEmailAddressPage))
         .flatMap(_.remove(DeclarationPage))
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapVersion = "10.7.0"
-  private val hmrcMongoVersion = "2.12.0"
+  private val hmrcMongoVersion = "2.13.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/test/controllers/monthlyreturns/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/monthlyreturns/CheckYourAnswersControllerSpec.scala
@@ -301,7 +301,12 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
 
     "must redirect to journey recovery on POST when ReturnTypePage is missing" in {
 
-      val application = applicationBuilder(userAnswers = Some(userAnswersWithCisId)).build()
+      val userAnswers = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       running(application) {
         val request = FakeRequest(POST, controllers.monthlyreturns.routes.CheckYourAnswersController.onSubmit().url)
@@ -398,7 +403,10 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
 
     "must redirect to already submitted page for a GET when submission journey is already completed" in {
       val userAnswers = userAnswersWithCisId
-        .set(SubmissionJourneyCompletedPage, true)
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionJourneyCompletedPage("2025-08"), true)
         .success
         .value
 
@@ -420,7 +428,10 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         .set(ReturnTypePage, ReturnType.MonthlyNilReturn)
         .success
         .value
-        .set(SubmissionJourneyCompletedPage, true)
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionJourneyCompletedPage("2025-08"), true)
         .success
         .value
 

--- a/test/controllers/monthlyreturns/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/monthlyreturns/CheckYourAnswersControllerSpec.scala
@@ -248,6 +248,19 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
       }
     }
 
+    "must redirect to journey recovery on GET when DateConfirmPaymentsPage is missing" in {
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCisId)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, controllers.monthlyreturns.routes.CheckYourAnswersController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
     "must redirect to journey recovery on POST when Journey is incomplete" in {
       val userAnswers = completeAnswers.remove(SubmitInactivityRequestPage).get
 

--- a/test/controllers/monthlyreturns/SubmissionSendingControllerSpec.scala
+++ b/test/controllers/monthlyreturns/SubmissionSendingControllerSpec.scala
@@ -76,7 +76,6 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
 
   private def stubSubmissionFlow(
     service: SubmissionService,
-    sessionDb: SessionRepository,
     status: String,
     createdId: String = "sub-123",
     endpoint: Option[ResponseEndPointDto] = None,
@@ -133,7 +132,7 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
     "redirects to polling page when status is PENDING" in {
       val mockService = mock[SubmissionService]
       val mockMongoDb = mock[SessionRepository]
-      stubSubmissionFlow(mockService, mockMongoDb, status = "PENDING")
+      stubSubmissionFlow(mockService, status = "PENDING")
 
       val app        = buildAppWith(Some(completeAnswers), mockService, mockMongoDb).build()
       val controller = app.injector.instanceOf[SubmissionSendingController]
@@ -147,7 +146,7 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
     "redirects to polling page when status is ACCEPTED" in {
       val mockService = mock[SubmissionService]
       val mockMongoDb = mock[SessionRepository]
-      stubSubmissionFlow(mockService, mockMongoDb, status = "ACCEPTED")
+      stubSubmissionFlow(mockService, status = "ACCEPTED")
 
       val app        = buildAppWith(Some(completeAnswers), mockService, mockMongoDb).build()
       val controller = app.injector.instanceOf[SubmissionSendingController]
@@ -161,7 +160,7 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
     "redirects to Unsuccessful when status is FATAL_ERROR" in {
       val mockService = mock[SubmissionService]
       val mockMongoDb = mock[SessionRepository]
-      stubSubmissionFlow(mockService, mockMongoDb, status = "FATAL_ERROR")
+      stubSubmissionFlow(mockService, status = "FATAL_ERROR")
 
       val app        = buildAppWith(Some(completeAnswers), mockService, mockMongoDb).build()
       val controller = app.injector.instanceOf[SubmissionSendingController]
@@ -200,7 +199,7 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
     "redirects to Submission Unsuccessful Resubmit page when status is STARTED" in {
       val mockService = mock[SubmissionService]
       val mockMongoDb = mock[SessionRepository]
-      stubSubmissionFlow(mockService, mockMongoDb, status = "STARTED")
+      stubSubmissionFlow(mockService, status = "STARTED")
 
       val app        = buildAppWith(Some(completeAnswers), mockService, mockMongoDb).build()
       val controller = app.injector.instanceOf[SubmissionSendingController]
@@ -278,12 +277,7 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
       val mockMongoDb = mock[SessionRepository]
 
       val (createdId, updatedAnswers, submitted) =
-        stubSubmissionFlow(
-          service = mockService,
-          sessionDb = mockMongoDb,
-          status = "PENDING",
-          isResubmission = true
-        )
+        stubSubmissionFlow(service = mockService, status = "PENDING", isResubmission = true)
 
       val app        = buildAppWith(Some(completeAnswers), mockService, mockMongoDb).build()
       val controller = app.injector.instanceOf[SubmissionSendingController]

--- a/test/controllers/monthlyreturns/SubmissionSendingControllerSpec.scala
+++ b/test/controllers/monthlyreturns/SubmissionSendingControllerSpec.scala
@@ -257,6 +257,22 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
       verifyNoInteractions(mockMongoDb)
     }
 
+    "redirects to JourneyRecovery when DateConfirmPaymentsPage is missing" in {
+      val mockService = mock[SubmissionService]
+      val mockMongoDb = mock[SessionRepository]
+
+      val app        = buildAppWith(Some(userAnswersWithCisId), mockService, mockMongoDb).build()
+      val controller = app.injector.instanceOf[SubmissionSendingController]
+
+      val result = controller.onPageLoad()(mkRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result).value mustBe recoveryRoute
+
+      verifyNoInteractions(mockService)
+      verifyNoInteractions(mockMongoDb)
+    }
+
     "passes isResubmission=true to submitToChrisAndPersist when an existing submission is reused" in {
       val mockService = mock[SubmissionService]
       val mockMongoDb = mock[SessionRepository]

--- a/test/controllers/monthlyreturns/SubmissionSendingControllerSpec.scala
+++ b/test/controllers/monthlyreturns/SubmissionSendingControllerSpec.scala
@@ -216,7 +216,10 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
       val mockMongoDb = mock[SessionRepository]
 
       val completedAnswers = userAnswersWithCisId
-        .set(SubmissionJourneyCompletedPage, true)
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionJourneyCompletedPage("2025-08"), true)
         .success
         .value
 
@@ -238,7 +241,7 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
       val mockMongoDb = mock[SessionRepository]
 
       val incompleteAnswers = completeAnswers
-        .remove(DateConfirmPaymentsPage)
+        .remove(DeclarationPage)
         .success
         .value
 
@@ -397,7 +400,12 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
       val mockService = mock[SubmissionService]
       val mockMongoDb = mock[SessionRepository]
 
-      val app = buildAppWith(Some(userAnswersWithCisId), mockService, mockMongoDb).build()
+      val userAnswers = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+
+      val app = buildAppWith(Some(userAnswers), mockService, mockMongoDb).build()
       val ctl = app.injector.instanceOf[SubmissionSendingController]
 
       val result = ctl.onPollAndRedirect()(mkPollRequest)
@@ -421,7 +429,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -458,7 +472,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -495,7 +515,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -532,7 +558,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -569,7 +601,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -610,7 +648,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -652,7 +696,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -693,7 +743,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -734,7 +790,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -771,7 +833,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -811,7 +879,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -851,7 +925,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -888,7 +968,13 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
         irMark = "IR-MARK-123",
         submittedAt = LocalDateTime.parse("2025-01-01T00:00:00")
       )
-      val uaWithSubmission  = userAnswersWithCisId.set(SubmissionDetailsPage, submissionDetails).success.value
+      val uaWithSubmission  = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionDetailsPage, submissionDetails)
+        .success
+        .value
 
       when(mockService.getPollInterval(any[UserAnswers]))
         .thenReturn(10)
@@ -915,7 +1001,10 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
       val mockMongoDb = mock[SessionRepository]
 
       val completedAnswers = userAnswersWithCisId
-        .set(SubmissionJourneyCompletedPage, true)
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
+        .set(SubmissionJourneyCompletedPage("2025-08"), true)
         .success
         .value
 
@@ -944,6 +1033,9 @@ final class SubmissionSendingControllerSpec extends SpecBase with MockitoSugar {
       )
 
       val uaWithSubmission = userAnswersWithCisId
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .success
+        .value
         .set(SubmissionDetailsPage, submissionDetails)
         .success
         .value

--- a/test/pages/submission/SubmissionJourneyCompletedPageSpec.scala
+++ b/test/pages/submission/SubmissionJourneyCompletedPageSpec.scala
@@ -24,11 +24,13 @@ class SubmissionJourneyCompletedPageSpec extends SpecBase {
   "SubmissionJourneyCompletedPage" - {
 
     "must have the correct path" in {
-      SubmissionJourneyCompletedPage.path mustBe JsPath \ "submissionJourneyCompleted"
+      val page = SubmissionJourneyCompletedPage("2026-08")
+
+      page.path mustBe (JsPath \ "submissionJourneyCompleted" \ "2026-08" \ "completed")
     }
 
     "must have the correct toString value" in {
-      SubmissionJourneyCompletedPage.toString mustBe "submissionJourneyCompleted"
+      SubmissionJourneyCompletedPage("2026-08").toString mustBe "submissionJourneyCompleted"
     }
   }
 }

--- a/test/services/MonthlyReturnServiceSpec.scala
+++ b/test/services/MonthlyReturnServiceSpec.scala
@@ -1195,14 +1195,25 @@ class MonthlyReturnServiceSpec extends SpecBase {
 
       when(originalUa.set(SubmissionJourneyCompletedPage("2025-08"), true))
         .thenReturn(scala.util.Success(updatedUa))
-      when(updatedUa.remove(DateConfirmPaymentsPage))
-        .thenReturn(scala.util.Failure(new RuntimeException("clear failed")))
 
       service.completeSubmissionJourney(originalUa).futureValue mustBe ()
 
       verify(originalUa).set(SubmissionJourneyCompletedPage("2025-08"), true)
       verify(updatedUa).remove(DateConfirmPaymentsPage)
       verifyNoInteractions(sessionRepo)
+    }
+
+    "return unit and not persist when DateConfirmPaymentsPage is missing" in {
+      val (service, _, sessionRepo) = newService()
+
+      val originalUa = UserAnswers("test-user")
+        .set(VerifySubcontractorsPage, true)
+        .get
+
+      service.completeSubmissionJourney(originalUa).futureValue mustBe ()
+
+      verify(sessionRepo, never()).set(any[UserAnswers])
+      verifyNoMoreInteractions(sessionRepo)
     }
   }
 

--- a/test/services/MonthlyReturnServiceSpec.scala
+++ b/test/services/MonthlyReturnServiceSpec.scala
@@ -1137,7 +1137,9 @@ class MonthlyReturnServiceSpec extends SpecBase {
       val (service, _, sessionRepo) = newService()
 
       val originalUa = UserAnswers("test-user")
-        .set(SubmissionJourneyCompletedPage, false)
+        .set(DateConfirmPaymentsPage, LocalDate.of(2025, 8, 5))
+        .get
+        .set(SubmissionJourneyCompletedPage("2025-08"), false)
         .get
         .set(VerifySubcontractorsPage, true)
         .get
@@ -1157,7 +1159,7 @@ class MonthlyReturnServiceSpec extends SpecBase {
       verify(sessionRepo).set(uaCaptor.capture())
 
       val savedUa = uaCaptor.getValue
-      savedUa.get(SubmissionJourneyCompletedPage) mustBe Some(true)
+      savedUa.get(SubmissionJourneyCompletedPage("2025-08")) mustBe Some(true)
       savedUa.get(VerifySubcontractorsPage) mustBe None
       savedUa.get(DeclarationPage) mustBe None
       savedUa.get(SubmitInactivityRequestPage) mustBe None
@@ -1170,12 +1172,15 @@ class MonthlyReturnServiceSpec extends SpecBase {
 
       val originalUa = mock(classOf[UserAnswers])
 
-      when(originalUa.set(SubmissionJourneyCompletedPage, true))
+      when(originalUa.get(DateConfirmPaymentsPage))
+        .thenReturn(Some(LocalDate.of(2025, 8, 31)))
+
+      when(originalUa.set(SubmissionJourneyCompletedPage("2025-08"), true))
         .thenReturn(scala.util.Failure(new RuntimeException("set failed")))
 
       service.completeSubmissionJourney(originalUa).futureValue mustBe ()
 
-      verify(originalUa).set(SubmissionJourneyCompletedPage, true)
+      verify(originalUa).set(SubmissionJourneyCompletedPage("2025-08"), true)
       verifyNoInteractions(sessionRepo)
     }
 
@@ -1185,14 +1190,17 @@ class MonthlyReturnServiceSpec extends SpecBase {
       val originalUa = mock(classOf[UserAnswers])
       val updatedUa  = mock(classOf[UserAnswers])
 
-      when(originalUa.set(SubmissionJourneyCompletedPage, true))
+      when(originalUa.get(DateConfirmPaymentsPage))
+        .thenReturn(Some(LocalDate.of(2025, 8, 31)))
+
+      when(originalUa.set(SubmissionJourneyCompletedPage("2025-08"), true))
         .thenReturn(scala.util.Success(updatedUa))
       when(updatedUa.remove(DateConfirmPaymentsPage))
         .thenReturn(scala.util.Failure(new RuntimeException("clear failed")))
 
       service.completeSubmissionJourney(originalUa).futureValue mustBe ()
 
-      verify(originalUa).set(SubmissionJourneyCompletedPage, true)
+      verify(originalUa).set(SubmissionJourneyCompletedPage("2025-08"), true)
       verify(updatedUa).remove(DateConfirmPaymentsPage)
       verifyNoInteractions(sessionRepo)
     }

--- a/test/services/guard/DuplicateMRCreationGuardSpec.scala
+++ b/test/services/guard/DuplicateMRCreationGuardSpec.scala
@@ -45,7 +45,7 @@ class DuplicateMRCreationGuardSpec extends AnyWordSpec with Matchers with ScalaF
 
   "DuplicateMRCreationGuardImpl.check" should {
 
-    "return NoDuplicate when NilReturnStatusPage is present" in {
+    "return NoDuplicate when NilReturnStatusPage is absent" in {
       val ua                               = emptyUserAnswers()
       implicit val request: DataRequest[_] = dataRequest(ua)
 

--- a/test/utils/UserAnswerUtilsSpec.scala
+++ b/test/utils/UserAnswerUtilsSpec.scala
@@ -275,6 +275,8 @@ class UserAnswerUtilsSpec extends SpecBase {
         .get
         .set(ResubmissionIdPage, 1L)
         .get
+        .set(NilReturnStatusPage, "STARTED")
+        .get
         .set(DeclarationPage, Set(Declaration.Confirmed))
         .get
         .set(SelectedSubcontractorPage(1), completeSub(1))
@@ -304,6 +306,7 @@ class UserAnswerUtilsSpec extends SpecBase {
       cleared.get(ConfirmationByEmailPage) mustBe None
       cleared.get(EnterYourEmailAddressPage) mustBe None
       cleared.get(ResubmissionIdPage) mustBe None
+      cleared.get(NilReturnStatusPage) mustBe None
       cleared.get(DeclarationPage) mustBe None
       cleared.get(SelectedSubcontractorPage(1)) mustBe None
       cleared.get(VerifySubcontractorsPage) mustBe None


### PR DESCRIPTION
Previously, the journey completion guard used a single boolean value in SubmissionJourneyCompletedPage to determine whether a monthly return journey had been completed. This prevented users from creating a second monthly return, regardless of the return period.

This change updates the guard to store the completion status per return period instead of using a shared true/false flag. `SubmissionJourneyCompletedPage` is now keyed by the period (for example, 2025-08), allowing users to start a new monthly return for a different period while still preventing duplicate submissions for the same period.

<img width="514" height="169" alt="image" src="https://github.com/user-attachments/assets/43138ff5-f260-497d-b4b3-2b3974c07fb7" />
