### PR TITLE
DTR - 7008 Welsh translation for returns journey

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -102,7 +102,7 @@ play-frontend-hmrc {
 }
 
 features {
-  welsh-translation: false
+  welsh-translation: true
   stub-sending-enabled: false
 }
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -185,7 +185,7 @@ monthlyreturns.returnType.value = Monthly nil return
 monthlyreturns.returnType.monthlyReturnValue = Monthly return
 
 monthlyreturns.enterYourEmailAddress.error.length = Your email address must be 132 characters or less
-monthlyreturns.enterYourEmailAddress.change.hidden = Enter your email address
+monthlyreturns.enterYourEmailAddress.change.hidden = Nodwch eich cyfeiriad e-bost
 monthlyreturns.enterYourEmailAddress.checkYourAnswersLabel = Cyfeiriad e-bost
 
 
@@ -308,6 +308,7 @@ monthlyreturns.verifiedStatusDeclaration.error.required = Dewiswch ‘Iawn’ os
 monthlyreturns.verifiedStatusDeclaration.checkYourAnswersLabel = Datganiad o’r statws dilysu
 monthlyreturns.employmentStatusDeclaration.checkYourAnswersLabel = Datganiad o’r statws cyflogaeth
 
+verifySubcontractors.warningIcon = Warning
 
 monthlyreturns.verifiedStatusDeclaration.change.hidden = Verified Status Declaration
 monthlyreturns.verifiedStatusDeclaration.legend = Has every subcontractor included on this return either been verified with HM Revenue & Customs, or been included in previous CIS returns in this, or the previous two tax years?
@@ -317,4 +318,7 @@ monthlyreturns.summarySubcontractorPayments.intro = You have added the payment d
 verifySubcontractors.error.required = Select yes if you want to verify your subcontractors now
 monthlyreturns.selectSubcontractors.noSubcontractors = No subcontractors have been added yet
 monthlyreturns.selectSubcontractors.includeThisMonth.accessibleLabel = Include {0}
+monthlyreturns.subcontractorDetailsAdded.add.hidden = Add payment details for {0}s
+monthlyreturns.subcontractorDetailsAdded.amend.hidden = Amend payment details for {0}
+
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,1 +1,320 @@
+service.name = Cynllun y Diwydiant Adeiladu
+
+
+site.continue = Parhau
+site.acceptAndContinue = Derbyn a pharhau
+site.govuk = GOV.UK
+site.no = Na
+site.yes = Iawn
+site.change = Newid
+site.remove = Tynnu
+site.back = Yn ôl
+site.confirm = Cadarnhau
+
+currency.pounds=£{0}
+
+
+error.title.prefix = Error:
+error.prefix = Error
+error.summary.title = There is a problem
+
+
+
+fileYourNilReturn.title = Cyflwyno’ch datganiad ‘dim’
+fileYourNilReturn.heading = Cyflwyno’ch datganiad ‘dim’
+fileYourNilReturn.p1 = Defnyddiwch y gwasanaeth hwn i gadarnhau nad ydych wedi talu unrhyw is-gontractwyr yn ystod mis treth.
+fileYourNilReturn.p2 = Gallwch hefyd gyflwyno cais anactifedd.
+
+
+monthlyreturns.dateConfirmPayments.title = Pa fis treth a blwyddyn dreth ydych chi’n cyflwyno datganiad ar eu cyfer?
+monthlyreturns.dateConfirmPayments.heading = Pa fis treth a blwyddyn dreth ydych chi’n cyflwyno datganiad ar eu cyfer?
+monthlyreturns.dateConfirmPayments.nilreturn.title = Pa fis treth a blwyddyn dreth ydych chi’n cyflwyno datganiad ‘dim’ ar eu cyfer?
+monthlyreturns.dateConfirmPayments.nilreturn.heading = Pa fis treth a blwyddyn dreth ydych chi’n cyflwyno datganiad ‘dim’ ar eu cyfer?
+monthlyreturns.dateConfirmPayments.paragraph = Mae ‘cyfnod datganiad’ yn rhedeg o 6ed y mis rydych yn cyflwyno datganiad ar ei gyfer hyd at 5ed y mis nesaf.
+monthlyreturns.dateConfirmPayments.warning = Mae’n ofynnol yn ôl y gyfraith i chi gyflwyno’r datganiad hwn erbyn y dyddiad cau (sef y 19eg o bob mis). Mae’n bosibl y codir cosb am ddatganiadau hwyr.
+monthlyreturns.dateConfirmPayments.p1.prefix = Ni allwch newid cyfnod datganiad unwaith i chi ddechrau ei gwblhau. Bydd yn rhaid i chi
+monthlyreturns.dateConfirmPayments.p1.link = ddileu’r datganiad presennol
+monthlyreturns.dateConfirmPayments.p1.suffix = cyn dechrau datganiad newydd ar gyfer yr un cyfnod.
+monthlyreturns.dateConfirmPayments.legendText = Mis treth a blwyddyn dreth
+monthlyreturns.dateConfirmPayments.helpText = Er enghraifft, 9 2025
+monthlyreturns.dateConfirmPayments.error.duplicate = Mae datganiad misol ar gyfer y dyddiad hwn yn bodoli eisoes
+monthlyreturns.dateConfirmNilPayments.error.required.month = Mae’n rhaid i chi nodi mis treth
+monthlyreturns.dateConfirmNilPayments.error.required.year = Mae’n rhaid i chi nodi blwyddyn dreth
+monthlyreturns.dateConfirmNilPayments.error.invalid.month = Mae’n rhaid i chi nodi mis treth
+monthlyreturns.dateConfirmNilPayments.error.invalid.year = Mae’n rhaid i chi nodi blwyddyn dreth
+monthlyreturns.dateConfirmNilPayments.error.invalid.maxAllowedFutureReturnPeriod = Mae’n rhaid i chi nodi blwyddyn dreth, ni all y dyddiad fod yn fwy na 3 chyfnod datganiad o flaen y dyddiad presennol
+monthlyreturns.dateConfirmNilPayments.error.invalid.earliestSupportedYear = Ni all cyfnod y datganiad fod cyn {0}
+
+monthlyreturns.submitInactivityRequest.title = Gwneud cais anactifedd
+monthlyreturns.submitInactivityRequest.heading = Gwneud cais anactifedd
+monthlyreturns.submitInactivityRequest.p1 = Rhwch wybod i CThEF nad ydych yn disgwyl talu unrhyw is-gontractwyr yn ystod y chwe mis nesaf.
+monthlyreturns.submitInactivityRequest.p2 = Os bydd eich cais yn cael ei dderbyn, ni fydd angen i chi gyflwyno datganiadau misol.
+monthlyreturns.submitInactivityRequest.insetText = Mae’n rhaid i chi roi gwybod i CThEF pan fyddwch yn dechrau talu is-gontractwyr eto. Gallwch wneud hyn drwy ffonio Llinell Gymorth CIS ar 0300 200 3210
+monthlyreturns.submitInactivityRequest.question = A ydych yn cyflwyno cais anactifedd?
+monthlyreturns.submitInactivityRequest.yes = Iawn
+monthlyreturns.submitInactivityRequest.no = Na
+monthlyreturns.submitInactivityRequest.error.required = Dewiswch ‘Iawn’ i gyflwyno cais anactifedd
+
+monthlyreturns.inactivityRequestWarning.title = Cais anactifedd
+monthlyreturns.inactivityRequestWarning.heading = Cais anactifedd
+monthlyreturns.inactivityRequestWarning.p = Rydych yn cyflwyno cais anactifedd. Os bydd eich cais yn cael ei dderbyn, bydd yn ddilys am chwe mis yn unig.
+monthlyreturns.inactivityRequestWarning.warning = Os byddwch yn talu unrhyw is-gontractwyr yn ystod y cyfnod hwn, bydd yn rhaid i chi gyflwyno datganiad misol.
+
+monthlyreturns.confirmationByEmail.title = A ydych am gael e-bost i gadarnhau bod y datganiad hwn wedi’i gyflwyno’n llwyddiannus?
+monthlyreturns.confirmationByEmail.heading = A ydych am gael e-bost i gadarnhau bod y datganiad hwn wedi’i gyflwyno’n llwyddiannus?
+monthlyreturns.confirmationByEmail.p = Gallwch ddefnyddio’r e-bost sydd gennym eisoes ar eich cyfer, neu nodi un arall
+monthlyreturns.confirmationByEmail.yes = Iawn
+monthlyreturns.confirmationByEmail.no = Na
+monthlyreturns.confirmationByEmail.error.required = Dewiswch ‘Iawn’ i nodi’r e-bost i’w ddefnyddio ar gyfer anfon e-bost cadarnhau atoch
+
+monthlyreturns.enterYourEmailAddress.title = Nodwch eich cyfeiriad e-bost
+monthlyreturns.enterYourEmailAddress.heading = Nodwch eich cyfeiriad e-bost
+monthlyreturns.enterYourEmailAddress.hint = Nodwch gyfeiriad e-bost i gael cadarnhad gan CThEF bod eich datganiad wedi’i gyflwyno
+monthlyreturns.enterYourEmailAddress.error.required = Nodwch gyfeiriad e-bost yn y fformat cywir, fel enw@enghraifft.com
+monthlyreturns.enterYourEmailAddress.error.invalid = Nodwch gyfeiriad e-bost yn y fformat cywir, fel enw@enghraifft.com
+
+monthlyreturns.declaration.title = Datganiad
+monthlyreturns.declaration.heading = Datganiad
+monthlyreturns.declaration.paragraph = Drwy barhau, rydych yn cadarnhau’r canlynol:
+monthlyreturns.declaration.listItem1 = nid oes unrhyw daliadau wedi’u gwneud i is-gontractwyr yn ystod y cyfnod hwn
+monthlyreturns.declaration.listItem2 = mae’r wybodaeth a nodwyd yn y datganiad hwn yn gywir hyd eithaf fy ngwybodaeth
+monthlyreturns.declaration.warning = Os byddwch yn rhoi unrhyw wybodaeth ffug, efallai y byddwch yn wynebu cosbau ac erlyniad.
+monthlyreturns.declaration.submit = Cadarnhau a pharhau
+
+monthlyreturns.checkYourAnswers.title = Gwiriwch eich atebion cyn cyflwyno’ch datganiad
+monthlyreturns.checkYourAnswers.heading = Gwiriwch eich atebion cyn cyflwyno’ch datganiad
+monthlyreturns.checkYourAnswers.returnDetails.heading = Manylion y datganiad
+monthlyreturns.checkYourAnswers.emailConfirmation.heading = E-bost cadarnhau
+monthlyreturns.checkYourAnswers.submitSection.button = Cadarnhau a pharhau
+monthlyreturns.returnType.checkYourAnswersLabel = Math o ddatganiad
+monthlyreturns.paymentsToSubcontractors.checkYourAnswersLabel = Taliadau i is-gontractwyr
+monthlyreturns.paymentsToSubcontractors.value = None
+
+monthlyreturns.submissionSuccess.title = Wedi llwyddo i gyflwyno {0}
+monthlyreturns.submissionSuccess.heading = Wedi llwyddo i gyflwyno {0}
+monthlyreturns.submissionSuccessful.panel.ref = Eich cyfeirnod
+monthlyreturns.submissionSuccessful.submitted.line = Cyflwynwyd am {0} on {1}
+monthlyreturns.submissionSuccessful.submissionDetails.heading = Manylion y cyflwyniad
+monthlyreturns.submissionSuccessful.contractorName = Enw’r contractwr
+monthlyreturns.submissionSuccessful.payeReference = Cyfeirnod TWE
+monthlyreturns.submissionSuccessful.submissionType = Math o gyflwyniad
+monthlyreturns.submissionSuccessful.returnPeriodEnded = Cyfnod dod i ben y datganiad
+monthlyreturns.submissionSuccessful.confirmationOfSuccessfulSubmission = Mae cadarnhad bod eich cyflwyniad wedi bod yn llwyddiannus wedi’i anfon i {0}
+monthlyreturns.submissionSuccessful.submissionHistory.p = Gallwch gael mynediad at fformat ‘darllen yn unig’ o’r datganiad hwn yn yr adran
+monthlyreturns.submissionSuccessful.submissionHistory.link = ‘hanes cyflwyniadau’
+monthlyreturns.submissionSuccessful.inset = Cadw’r dudalen hon neu argraffu copi ar gyfer eich cofnodion. Os byddwch yn cysylltu â CThEF, bydd angen eich cyfeirnod cyflwyno arnoch.
+monthlyreturns.submissionSuccessful.print = Argraffu’r dudalen hon
+monthlyreturns.submissionSuccessful.backToManageYourCISReturn.link = Yn ôl i ‘Rheoli eich datganiad CIS’
+monthlyreturns.submissionSuccessful.questionsAboutReturnSubmission.p = Os oes gennych unrhyw gwestiynau am eich datganiad, cysylltwch â
+monthlyreturns.submissionSuccessful.questionsAboutReturnSubmission.link = Llinell Gymorth Gwasanaethau ar-lein CThEF (yn agor tab newydd)
+monthlyreturns.submissionSuccessful.feedback.heading = Cyn i chi fynd
+monthlyreturns.submissionSuccessful.feedback.p1 = Mae’ch adborth yn ein helpu i wella ein gwasanaeth.
+monthlyreturns.submissionSuccessful.feedback.p2 = i rannu’ch adborth ar y gwasanaeth hwn.
+monthlyreturns.submissionSuccessful.feedback.p2.link = Llenwch arolwg byr
+monthlyreturns.returnType.MonthlyNilReturn = Nil return
+monthlyreturns.returnType.MonthlyAmendedNilReturn = Nil return
+monthlyreturns.returnType.MonthlyStandardReturn = Monthly return
+monthlyreturns.returnType.MonthlyAmendedStandardReturn = Monthly return
+monthlyreturns.submissionSuccessful.whatHappensNext.h2 = Yr hyn sy’n digwydd nesaf
+monthlyreturns.submissionSuccessful.whatHappensNext.p = Ni wnaethoch nodi e-bost wrth i chi gyflwyno’r datganiad hwn. Os ydych am nodi e-bost, bydd angen i chi newid eich manylion cyswllt yn yr adran ynglŷn â’ch sefydliad/ffỳrm. Bydd hyn i’w weld yn eich gwasanaethau CThEF.
+
+monthlyreturns.submittedNoReceipt.title = Wedi llwyddo i gyflwyno {0}
+monthlyreturns.submittedNoReceipt.heading = Wedi llwyddo i gyflwyno {0}
+monthlyreturns.submittedNoReceipt.p1 = Cyflwynwyd am {0} on {1}
+monthlyreturns.submittedNoReceipt.details.h2 = Manylion y cyflwyniad
+monthlyreturns.submittedNoReceipt.details.contractorName = Enw’r contractwr
+monthlyreturns.submittedNoReceipt.details.payeReference = Cyfeirnod TWE
+monthlyreturns.submittedNoReceipt.details.submissionType = Math o gyflwyniad
+monthlyreturns.submittedNoReceipt.details.returnPeriodEnded = Cyfnod dod i ben y datganiad
+monthlyreturns.submittedNoReceipt.confirmationOfSuccessfulSubmission = Mae cadarnhad bod eich cyflwyniad wedi bod yn llwyddiannus wedi’i anfon i {0}
+monthlyreturns.submittedNoReceipt.submissionHistory.p = Gallwch gael mynediad at fformat ‘darllen yn unig’ o’r datganiad hwn yn yr adran
+monthlyreturns.submittedNoReceipt.submissionHistory.link = ‘hanes cyflwyniadau’
+monthlyreturns.submittedNoReceipt.backToManageYourCISReturn.link = Yn ôl i ‘Rheoli eich datganiad CIS’
+monthlyreturns.submittedNoReceipt.questionsAboutReturnSubmission.p = Os oes gennych unrhyw gwestiynau am eich datganiad, cysylltwch â
+monthlyreturns.submittedNoReceipt.questionsAboutReturnSubmission.link = Llinell Gymorth Gwasanaethau ar-lein CThEF (yn agor tab newydd)
+monthlyreturns.submittedNoReceipt.feedback.heading = Cyn i chi fynd
+monthlyreturns.submittedNoReceipt.feedback.p1 = Mae’ch adborth yn ein helpu i wella ein gwasanaeth.
+monthlyreturns.submittedNoReceipt.feedback.p2 = i rannu’ch adborth ar y gwasanaeth hwn.
+monthlyreturns.submittedNoReceipt.feedback.p2.link = Llenwch arolwg byr
+monthlyreturns.submittedNoReceipt.whatHappensNext.heading = Yr hyn sy’n digwydd nesaf
+monthlyreturns.submittedNoReceipt.whatHappensNext.p = Ni wnaethoch nodi e-bost wrth i chi gyflwyno’r datganiad hwn. Os ydych am nodi e-bost, bydd angen i chi newid eich manylion cyswllt yn yr adran ynglŷn â’ch sefydliad/ffỳrm. Bydd hyn i’w weld yn eich gwasanaethau CThEF.
+
+monthlyreturns.submissionUnsuccessful.title = Mae yna broblem dechnegol gyda’ch cyflwyniad
+monthlyreturns.submissionUnsuccessful.heading.h1 = Mae yna broblem dechnegol gyda’ch cyflwyniad
+monthlyreturns.submissionUnsuccessful.paragraph.p1 = Ni allwch ail-gyflwyno.
+monthlyreturns.submissionUnsuccessful.warning = Mae’n rhaid i chi gyflwyno’ch datganiad misol erbyn y dyddiad cau er mwyn osgoi cosbau.
+monthlyreturns.submissionUnsuccessful.links.prefix = Mae’n rhaid i chi gysylltu â
+monthlyreturns.submissionUnsuccessful.hmrcOnlineServicesHelpdesk = Llinell Gymorth Gwasanaethau ar-lein CThEF (yn agor tab newydd)
+monthlyreturns.submissionUnsuccessful.details.intro = Bydd angen i chi nodi’r canlynol:
+monthlyreturns.submissionUnsuccessful.details.li1 = eich cyfeirnod PAYE, a elwir hefyd yn ‘Cyfeirnod Cyflogwr (ERN)’
+monthlyreturns.submissionUnsuccessful.details.li2 = y dyddiad y gwnaethoch geisio cyflwyno’r datganiad
+monthlyreturns.submissionUnsuccessful.submit = Yn ôl i ‘Rheoli’ch Datganiad CIS’
+
+monthlyreturns.submissionUnsuccessfulResubmit.title = Mae yna broblem gyda’ch cyflwyniad
+monthlyreturns.submissionUnsuccessfulResubmit.heading = Mae yna broblem gyda’ch cyflwyniad
+monthlyreturns.submissionUnsuccessfulResubmit.p1.links.prefix = Mae’n rhaid i chi fynd yn ôl i’r adran
+monthlyreturns.submissionUnsuccessfulResubmit.p1.links.text = Rheoli’ch Datganiad CIS
+monthlyreturns.submissionUnsuccessfulResubmit.p1.links.suffix = a chyflwyno eto.
+monthlyreturns.submissionUnsuccessfulResubmit.p2.warning = Mae’n rhaid i chi gyflwyno’ch datganiad misol erbyn y dyddiad cau er mwyn osgoi cosbau.
+monthlyreturns.submissionUnsuccessfulResubmit.p3.links.prefix = Os ydych yn wynebu problemau technegol, cysylltwch â
+monthlyreturns.submissionUnsuccessfulResubmit.p3.links.text = Llinell Gymorth Gwasanaethau ar-lein CThEF (yn agor tab newydd)
+monthlyreturns.submissionUnsuccessfulResubmit.p4 = Bydd angen i chi nodi’r canlynol:
+monthlyreturns.submissionUnsuccessfulResubmit.list.l1 = eich cyfeirnod PAYE, a elwir hefyd yn ‘Cyfeirnod Cyflogwr (ERN)’
+monthlyreturns.submissionUnsuccessfulResubmit.list.l2 = y dyddiad y gwnaethoch geisio cyflwyno’r datganiad
+monthlyreturns.submissionUnsuccessfulResubmit.p5.links.text = Yn ôl i ‘Rheoli’ch Datganiad CIS’
+
+monthlyreturns.submissionSending.title = Mae’ch cyflwyniad yn cael ei anfon at CThEF
+monthlyreturns.submissionSending.h1 = Mae’ch cyflwyniad yn cael ei anfon at CThEF
+monthlyreturns.submissionSending.paragraph = Wrth i’ch cyflwyniad gael ei brosesu, peidiwch ag adfywio’r dudalen hon na defnyddio’r botwm i fynd yn ôl.
+
+monthlyreturns.submissionAwaiting.title = Cyflwyniad ar y gweill
+monthlyreturns.submissionAwaiting.heading = Cyflwyniad ar y gweill
+monthlyreturns.submissionAwaiting.paragraph.p1 = Mae’ch cyflwyniad yn cael ei brosesu ar hyn o bryd. Mae’r broses hon fel arfer yn cymryd ychydig funudau, ond gall gymryd yn hirach yn ystod cyfnodau prysur.
+monthlyreturns.submissionAwaiting.paragraph.p2 = Gallwch wirio a yw’ch cyflwyniad wedi cael ei brosesu drwy adfywio’ch tudalen neu drwy wirio’r adran ‘datganiadau sydd wedi’u cyflwyno’.
+monthlyreturns.submissionAwaiting.details.summary = Yr hyn sy’n digwydd yn ystod y cam prosesu
+monthlyreturns.submissionAwaiting.details.paragraph.p1 = Wrth i’ch cyflwyniad gael ei brosesu:
+monthlyreturns.submissionAwaiting.details.paragraph.p2 = Unwaith i’r cam prosesu gael ei gwblhau, gallwch fwrw golwg dros gadarnhad o’ch cyflwyniad a’r cyfeirnod.
+monthlyreturns.submissionAwaiting.details.list.l1 = mae systemau CThEF yn dilysu’ch datganiad
+monthlyreturns.submissionAwaiting.details.list.l2 = mae’ch datganiad yn cael ei wirio
+monthlyreturns.submissionAwaiting.details.list.l3 = mae’ch cyfeirnod cyflwyno yn cael ei greu
+monthlyreturns.submissionAwaiting.links.prefix = Ar gyfer problemau technegol, cysylltwch â
+monthlyreturns.submissionAwaiting.links.hmrcOnlineServicesHelpdesk = Llinell Gymorth Gwasanaethau ar-lein CThEF (yn agor tab newydd)
+monthlyreturns.submissionAwaiting.links.submit = Yn ôl i ‘Rheoli’ch Datganiad CIS’
+
+monthlyreturns.returnType.value = Monthly nil return
+monthlyreturns.returnType.monthlyReturnValue = Monthly return
+
+monthlyreturns.enterYourEmailAddress.error.length = Your email address must be 132 characters or less
+monthlyreturns.enterYourEmailAddress.change.hidden = Enter your email address
+monthlyreturns.enterYourEmailAddress.checkYourAnswersLabel = Cyfeiriad e-bost
+
+
+monthlyreturns.confirmationByEmail.checkYourAnswersLabel = A ydych am gael cadarnhad o’ch cyflwyniad drwy e-bost?
+monthlyreturns.confirmationByEmail.change.hidden = A ydych am gael cadarnhad o’ch cyflwyniad drwy e-bost
+
+
+monthlyreturns.submitInactivityRequest.checkYourAnswersLabel = Cais anactifedd
+monthlyreturns.submitInactivityRequest.change.hidden = inactivity request
+
+
+monthlyreturns.dateConfirmPayments.checkYourAnswersLabel = Cyfnod dod i ben y datganiad
+monthlyreturns.dateConfirmNilPayments.checkYourAnswersLabel = Cyfnod dod i ben y datganiad
+
+fileYourMonthlyCisReturn.title = Cyflwyno’ch Datganiad CIS misol
+fileYourMonthlyCisReturn.heading = Cyflwyno’ch Datganiad CIS misol
+fileYourMonthlyCisReturn.p1 = Defnyddiwch y gwasanaeth hwn i gyflwyno’ch datganiad misol ar gyfer y Cynllun y Diwydiant Adeiladu (CIS).
+fileYourMonthlyCisReturn.p2 = Bydd angen i chi nodi’r mis treth a’r flwyddyn dreth ar y datganiad.
+
+monthlyreturns.selectSubcontractors.title = Pa is-gontractwyr ydych chi am eu cynnwys?
+monthlyreturns.selectSubcontractors.heading = Pa is-gontractwyr ydych chi am eu cynnwys?
+monthlyreturns.selectSubcontractors.p1 = Rhowch wybod i ni am yr is-gontractwyr rydych yn eu cynnwys yn y datganid misol hwn.
+
+monthlyreturns.selectSubcontractors.p2 = Gallwch hefyd ychwanegu is-gontractwyr at eich rhestr, tynnu is-gontractwyr o’ch rhestr, a
+monthlyreturns.selectSubcontractors.p2.link = diweddaru’ch rhestr
+monthlyreturns.selectSubcontractors.selectAll.link = Dewis popeth
+monthlyreturns.selectSubcontractors.deselectAll.link = Dad-ddewis popeth
+monthlyreturns.selectSubcontractors.table.th.includeThisMonth = I’w cynnwys
+monthlyreturns.selectSubcontractors.table.th.name = Enw
+monthlyreturns.selectSubcontractors.table.th.verificationRequired = Wedi’i ddilysu gan ddefnyddio’r gwasanaeth hwn
+monthlyreturns.selectSubcontractors.table.th.verificationNumber = Rhif dilysu
+monthlyreturns.selectSubcontractors.table.th.taxTreatment = Triniaeth o ran treth
+monthlyreturns.selectSubcontractors.error.required = Nid ydych wedi dewis unrhyw is-gontractwyr
+
+verifySubcontractors.title = Mae gennych is-gontractwyr sydd heb eu dilysu
+verifySubcontractors.heading = Mae gennych is-gontractwyr sydd heb eu dilysu
+verifySubcontractors.warningText = Mae un neu fwy o’ch is-gontractwyr heb eu dilysu. Bydd unrhyw is-gontractwyr sydd heb eu dilysu yn cael eu trethu ar gyfradd uwch.
+verifySubcontractors.P1 = A ydych am ddilysu’ch is-gontractwyr nawr?
+verifySubcontractors.yes = Iawn
+verifySubcontractors.yes.hint = Byddwch yn cael eich cyfeirio at y gwasanaeth dilysu
+verifySubcontractors.no = Na
+verifySubcontractors.no.hint = Bydd treth yn cael ei didynnu ar gyfradd uwch hyd nes bod y broses ddilysu wedi dod i ben
+
+monthlyreturns.subcontractorDetailsAdded.error.required = Dewiswch ‘Iawn’ i ychwanegu is-gontractwr arall
+monthlyreturns.subcontractorDetailsAdded.error.incomplete = Nid ydych wedi nodi manylion talu ar gyfer yr holl is-gontractwyr rydych wedi’u dewis
+monthlyreturns.subcontractorDetailsAdded.heading.single = Rydych wedi ychwanegu un is-gontractwr
+monthlyreturns.subcontractorDetailsAdded.heading.multiple = Rydych wedi ychwanegu {0} o is-gontractwyr
+monthlyreturns.subcontractorDetailsAdded.question = A oes angen i chi ychwanegu rhagor o is-gontractwyr?
+monthlyreturns.subcontractorDetailsAdded.amend = Diwygio manylion talu
+monthlyreturns.subcontractorDetailsAdded.amend.hidden = Amend payment details for {0}
+monthlyreturns.subcontractorDetailsAdded.add = Ychwanegu manylion talu
+monthlyreturns.subcontractorDetailsAdded.add.hidden = Add payment details for {0}s
+monthlyreturns.subcontractorDetailsAdded.remove.hidden = Remove {0} from the list
+monthlyreturns.subcontractorDetailsAdded.cancelAmendment = Canslo’r diwygiad
+
+paymentDetails.title = How much did you pay to this subcontractor in total?
+paymentDetails.heading = Beth oedd y cyfanswm y gwnaethoch ei dalu i {0}?
+paymentDetails.hint = Nodwch y swm gros, heb gynnwys TAW nac unrhyw ddidyniadau. Talgrynnwch i lawr i’r bunt agosaf.
+paymentDetails.error.required = Nodwch gyfanswm y taliadau a wnaed
+paymentDetails.error.invalid = Nodwch gyfanswm y taliadau a wnaed mewn punnoedd, wedi’i dalgrynnu i lawr i’r bunt agosaf
+paymentDetails.error.maxLength = Mae’n rhaid i gyfanswm y taliadau fod yn llai na £99,999,999
+paymentDetails.error.maxValue = Mae’n rhaid i gyfanswm y taliadau fod yn llai na £99,999,999
+
+monthlyreturns.costOfMaterials.title = How much did this subcontractor pay in material costs?
+monthlyreturns.costOfMaterials.heading = Faint y gwnaeth {0} ei dalu am gost y deunyddiau?
+monthlyreturns.costOfMaterials.hint = Nodwch gyfanswm cost y deunyddiau a dalwyd gan yr is-gontractwr. Talgrynnwch i lawr i’r bunt agosaf.
+monthlyreturns.costOfMaterials.error.required = Nodwch gyfanswm cost y deunyddiau mewn punnoedd, wedi’i dalgrynnu i lawr i’r bunt agosaf
+monthlyreturns.costOfMaterials.error.invalid = Nodwch gyfanswm cost y deunyddiau mewn punnoedd, wedi’i dalgrynnu i lawr i’r bunt agosaf
+monthlyreturns.costOfMaterials.error.maxLength = Mae’n rhaid i gyfanswm cost y deunyddiau fod yn llai na £99,999,999
+monthlyreturns.costOfMaterials.error.maxValue = Mae’n rhaid i gyfanswm cost y deunyddiau fod yn llai na £99,999,999
+
+monthlyreturns.totalTaxDeducted.title = How much tax in total did you deduct from this subcontractor?
+monthlyreturns.totalTaxDeducted.heading = Beth oedd cyfanswm y dreth y gwnaethoch ei didynnu o {0}?
+monthlyreturns.totalTaxDeducted.hintText = Nodwch gyfanswm y dreth y gwnaethoch ei didynnu o’r is-gontractwr mewn punnoedd a cheiniogau, fel £300.00 neu £450.33
+monthlyreturns.totalTaxDeducted.error.maxValue = Mae’n rhaid i gyfanswm y dreth a ddidynnwyd fod yn llai na £99,999,999
+monthlyreturns.totalTaxDeducted.error.maxLength = Mae’n rhaid i gyfanswm y dreth a ddidynnwyd fod yn llai na £99,999,999
+monthlyreturns.totalTaxDeducted.error.invalid = Nodwch gyfanswm y dreth a ddidynnwyd yn y fformat cywir, gan ddefnyddio punnoedd a cheiniogau
+monthlyreturns.totalTaxDeducted.error.required = Nodwch gyfanswm y dreth a ddidynnwyd yn y fformat cywir, gan ddefnyddio punnoedd a cheiniogau
+
+
+monthlyreturns.confirmSubcontractorRemoval.title = A ydych chi’n siŵr eich bod am dynnu’r is-gontractw?
+monthlyreturns.confirmSubcontractorRemoval.heading = A ydych chi’n siŵr eich bod am dynnu {0}?
+monthlyreturns.confirmSubcontractorRemoval.error.required = Dewiswch ‘Iawn’ os ydych am dynnu’r is-gontractwr hwn
+
+monthlyreturns.checkAnswersTotalPayments.title = Gwiriwch eich atebion ar gyfer yr is-gontractwr
+monthlyreturns.checkAnswersTotalPayments.heading = Gwiriwch eich atebion ar gyfer {0}
+monthlyreturns.checkAnswersTotalPayments.details.totalPaymentsMadeToSubcontractors = Cyfanswm y taliadau i’r is-gontractwr
+monthlyreturns.checkAnswersTotalPayments.details.totalCostOfMaterials = Cyfanswm cost y deunyddiau
+monthlyreturns.checkAnswersTotalPayments.details.totalCisDeductions = Cyfanswm y didyniadau CIS
+
+monthlyreturns.changeAnswersTotalPayments.title = Newid manylion yr is-gontractwr
+monthlyreturns.changeAnswersTotalPayments.heading = Newid manylion {0}
+monthlyreturns.changeAnswersTotalPayments.details.totalPaymentsMadeToSubcontractors = Cyfanswm y taliadau i’r is-gontractwr
+monthlyreturns.changeAnswersTotalPayments.details.totalCostOfMaterials = Cyfanswm cost y deunyddiau
+monthlyreturns.changeAnswersTotalPayments.details.totalCisDeductions = Cyfanswm y didyniadau CIS
+
+monthlyreturns.summarySubcontractorPayments.title = Crynodeb o’r taliadau a wnaed
+monthlyreturns.summarySubcontractorPayments.heading = Crynodeb o’r taliadau a wnaed
+monthlyreturns.summarySubcontractorPayments.totalPayments.label = Cyfanswm y taliadau i’r is-gontractwr
+monthlyreturns.summarySubcontractorPayments.totalMaterialsCost.label = Cyfanswm cost y deunyddiau
+monthlyreturns.summarySubcontractorPayments.totalCisDeductions.label = Cyfanswm y didyniadau CIS
+
+monthlyreturns.paymentDetailsConfirmation.title = A ydych chi’n cadarnhau bod yr wybodaeth yn y datganiad hwn yn gywir?
+monthlyreturns.paymentDetailsConfirmation.heading = A ydych chi’n cadarnhau bod yr wybodaeth yn y datganiad hwn yn gywir?
+monthlyreturns.paymentDetailsConfirmation.hint = Drwy gadarnhau, rydych yn datgan eich bod wedi dewis is-gontractwyr a ddefnyddiwyd yn ystod y cyfnod adrodd hwn, hyd eithaf eich gwybodaeth
+monthlyreturns.paymentDetailsConfirmation.yes = Iawn, mae’r holl wybodaeth yn gywir ac yn gyflawn
+monthlyreturns.paymentDetailsConfirmation.no = Na, rwyf am wneud newidiadau
+monthlyreturns.paymentDetailsConfirmation.error.required =  Dewiswch ‘Iawn’ i gadarnhau bod yr wybodaeth rydych wedi’i nodi yn gywir
+monthlyreturns.paymentDetailsConfirmation.cancelAmendment = Canslo’r diwygiad
+
+monthlyreturns.employmentStatusDeclaration.title = Datganiad o’r statws cyflogaeth
+monthlyreturns.employmentStatusDeclaration.heading = Datganiad o’r statws cyflogaeth
+monthlyreturns.employmentStatusDeclaration.error.required = Dewiswch ‘Iawn’ i gadarnhau statws cyflogaeth eich is-gontractwyr. Dewiswch ‘Na’ os nad yw eu statws cyflogaeth wedi’u cadarnhau
+monthlyreturns.employmentStatusDeclaration.confirm = Cadarnhau
+
+monthlyreturns.verifiedStatusDeclaration.title = Datganiad o’r statws dilysu
+monthlyreturns.verifiedStatusDeclaration.heading = Datganiad o’r statws dilysu
+monthlyreturns.verifiedStatusDeclaration.error.required = Dewiswch ‘Iawn’ os yw’ch is-gontractwyr wedi’u dilysu
+
+monthlyreturns.verifiedStatusDeclaration.checkYourAnswersLabel = Datganiad o’r statws dilysu
+monthlyreturns.employmentStatusDeclaration.checkYourAnswersLabel = Datganiad o’r statws cyflogaeth
+
+
+monthlyreturns.verifiedStatusDeclaration.change.hidden = Verified Status Declaration
+monthlyreturns.verifiedStatusDeclaration.legend = Has every subcontractor included on this return either been verified with HM Revenue & Customs, or been included in previous CIS returns in this, or the previous two tax years?
+monthlyreturns.employmentStatusDeclaration.legend = Has the employment status of each individual included on this return been considered and have payments not been made under contracts of employment?
+monthlyreturns.employmentStatusDeclaration.change.hidden = EmploymentStatusDeclaration
+monthlyreturns.summarySubcontractorPayments.intro = You have added the payment details of {0} subcontractors.
+verifySubcontractors.error.required = Select yes if you want to verify your subcontractors now
+monthlyreturns.selectSubcontractors.noSubcontractors = No subcontractors have been added yet
+monthlyreturns.selectSubcontractors.includeThisMonth.accessibleLabel = Include {0}
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -14,10 +14,6 @@ site.confirm = Cadarnhau
 currency.pounds=£{0}
 
 
-error.title.prefix = Error:
-error.prefix = Error
-error.summary.title = There is a problem
-
 
 
 fileYourNilReturn.title = Cyflwyno’ch datganiad ‘dim’
@@ -93,7 +89,6 @@ monthlyreturns.paymentsToSubcontractors.value = None
 monthlyreturns.submissionSuccess.title = Wedi llwyddo i gyflwyno {0}
 monthlyreturns.submissionSuccess.heading = Wedi llwyddo i gyflwyno {0}
 monthlyreturns.submissionSuccessful.panel.ref = Eich cyfeirnod
-monthlyreturns.submissionSuccessful.submitted.line = Cyflwynwyd am {0} on {1}
 monthlyreturns.submissionSuccessful.submissionDetails.heading = Manylion y cyflwyniad
 monthlyreturns.submissionSuccessful.contractorName = Enw’r contractwr
 monthlyreturns.submissionSuccessful.payeReference = Cyfeirnod TWE
@@ -111,16 +106,11 @@ monthlyreturns.submissionSuccessful.feedback.heading = Cyn i chi fynd
 monthlyreturns.submissionSuccessful.feedback.p1 = Mae’ch adborth yn ein helpu i wella ein gwasanaeth.
 monthlyreturns.submissionSuccessful.feedback.p2 = i rannu’ch adborth ar y gwasanaeth hwn.
 monthlyreturns.submissionSuccessful.feedback.p2.link = Llenwch arolwg byr
-monthlyreturns.returnType.MonthlyNilReturn = Nil return
-monthlyreturns.returnType.MonthlyAmendedNilReturn = Nil return
-monthlyreturns.returnType.MonthlyStandardReturn = Monthly return
-monthlyreturns.returnType.MonthlyAmendedStandardReturn = Monthly return
 monthlyreturns.submissionSuccessful.whatHappensNext.h2 = Yr hyn sy’n digwydd nesaf
 monthlyreturns.submissionSuccessful.whatHappensNext.p = Ni wnaethoch nodi e-bost wrth i chi gyflwyno’r datganiad hwn. Os ydych am nodi e-bost, bydd angen i chi newid eich manylion cyswllt yn yr adran ynglŷn â’ch sefydliad/ffỳrm. Bydd hyn i’w weld yn eich gwasanaethau CThEF.
 
 monthlyreturns.submittedNoReceipt.title = Wedi llwyddo i gyflwyno {0}
 monthlyreturns.submittedNoReceipt.heading = Wedi llwyddo i gyflwyno {0}
-monthlyreturns.submittedNoReceipt.p1 = Cyflwynwyd am {0} on {1}
 monthlyreturns.submittedNoReceipt.details.h2 = Manylion y cyflwyniad
 monthlyreturns.submittedNoReceipt.details.contractorName = Enw’r contractwr
 monthlyreturns.submittedNoReceipt.details.payeReference = Cyfeirnod TWE
@@ -181,10 +171,6 @@ monthlyreturns.submissionAwaiting.links.prefix = Ar gyfer problemau technegol, c
 monthlyreturns.submissionAwaiting.links.hmrcOnlineServicesHelpdesk = Llinell Gymorth Gwasanaethau ar-lein CThEF (yn agor tab newydd)
 monthlyreturns.submissionAwaiting.links.submit = Yn ôl i ‘Rheoli’ch Datganiad CIS’
 
-monthlyreturns.returnType.value = Monthly nil return
-monthlyreturns.returnType.monthlyReturnValue = Monthly return
-
-monthlyreturns.enterYourEmailAddress.error.length = Your email address must be 132 characters or less
 monthlyreturns.enterYourEmailAddress.change.hidden = Nodwch eich cyfeiriad e-bost
 monthlyreturns.enterYourEmailAddress.checkYourAnswersLabel = Cyfeiriad e-bost
 
@@ -194,7 +180,6 @@ monthlyreturns.confirmationByEmail.change.hidden = A ydych am gael cadarnhad o�
 
 
 monthlyreturns.submitInactivityRequest.checkYourAnswersLabel = Cais anactifedd
-monthlyreturns.submitInactivityRequest.change.hidden = inactivity request
 
 
 monthlyreturns.dateConfirmPayments.checkYourAnswersLabel = Cyfnod dod i ben y datganiad
@@ -235,13 +220,9 @@ monthlyreturns.subcontractorDetailsAdded.heading.single = Rydych wedi ychwanegu 
 monthlyreturns.subcontractorDetailsAdded.heading.multiple = Rydych wedi ychwanegu {0} o is-gontractwyr
 monthlyreturns.subcontractorDetailsAdded.question = A oes angen i chi ychwanegu rhagor o is-gontractwyr?
 monthlyreturns.subcontractorDetailsAdded.amend = Diwygio manylion talu
-monthlyreturns.subcontractorDetailsAdded.amend.hidden = Amend payment details for {0}
 monthlyreturns.subcontractorDetailsAdded.add = Ychwanegu manylion talu
-monthlyreturns.subcontractorDetailsAdded.add.hidden = Add payment details for {0}s
-monthlyreturns.subcontractorDetailsAdded.remove.hidden = Remove {0} from the list
 monthlyreturns.subcontractorDetailsAdded.cancelAmendment = Canslo’r diwygiad
 
-paymentDetails.title = How much did you pay to this subcontractor in total?
 paymentDetails.heading = Beth oedd y cyfanswm y gwnaethoch ei dalu i {0}?
 paymentDetails.hint = Nodwch y swm gros, heb gynnwys TAW nac unrhyw ddidyniadau. Talgrynnwch i lawr i’r bunt agosaf.
 paymentDetails.error.required = Nodwch gyfanswm y taliadau a wnaed
@@ -249,7 +230,6 @@ paymentDetails.error.invalid = Nodwch gyfanswm y taliadau a wnaed mewn punnoedd,
 paymentDetails.error.maxLength = Mae’n rhaid i gyfanswm y taliadau fod yn llai na £99,999,999
 paymentDetails.error.maxValue = Mae’n rhaid i gyfanswm y taliadau fod yn llai na £99,999,999
 
-monthlyreturns.costOfMaterials.title = How much did this subcontractor pay in material costs?
 monthlyreturns.costOfMaterials.heading = Faint y gwnaeth {0} ei dalu am gost y deunyddiau?
 monthlyreturns.costOfMaterials.hint = Nodwch gyfanswm cost y deunyddiau a dalwyd gan yr is-gontractwr. Talgrynnwch i lawr i’r bunt agosaf.
 monthlyreturns.costOfMaterials.error.required = Nodwch gyfanswm cost y deunyddiau mewn punnoedd, wedi’i dalgrynnu i lawr i’r bunt agosaf
@@ -257,7 +237,6 @@ monthlyreturns.costOfMaterials.error.invalid = Nodwch gyfanswm cost y deunyddiau
 monthlyreturns.costOfMaterials.error.maxLength = Mae’n rhaid i gyfanswm cost y deunyddiau fod yn llai na £99,999,999
 monthlyreturns.costOfMaterials.error.maxValue = Mae’n rhaid i gyfanswm cost y deunyddiau fod yn llai na £99,999,999
 
-monthlyreturns.totalTaxDeducted.title = How much tax in total did you deduct from this subcontractor?
 monthlyreturns.totalTaxDeducted.heading = Beth oedd cyfanswm y dreth y gwnaethoch ei didynnu o {0}?
 monthlyreturns.totalTaxDeducted.hintText = Nodwch gyfanswm y dreth y gwnaethoch ei didynnu o’r is-gontractwr mewn punnoedd a cheiniogau, fel £300.00 neu £450.33
 monthlyreturns.totalTaxDeducted.error.maxValue = Mae’n rhaid i gyfanswm y dreth a ddidynnwyd fod yn llai na £99,999,999
@@ -266,7 +245,7 @@ monthlyreturns.totalTaxDeducted.error.invalid = Nodwch gyfanswm y dreth a ddidyn
 monthlyreturns.totalTaxDeducted.error.required = Nodwch gyfanswm y dreth a ddidynnwyd yn y fformat cywir, gan ddefnyddio punnoedd a cheiniogau
 
 
-monthlyreturns.confirmSubcontractorRemoval.title = A ydych chi’n siŵr eich bod am dynnu’r is-gontractw?
+monthlyreturns.confirmSubcontractorRemoval.title = A ydych chi’n siŵr eich bod am dynnu’r is-gontractwr?
 monthlyreturns.confirmSubcontractorRemoval.heading = A ydych chi’n siŵr eich bod am dynnu {0}?
 monthlyreturns.confirmSubcontractorRemoval.error.required = Dewiswch ‘Iawn’ os ydych am dynnu’r is-gontractwr hwn
 
@@ -308,14 +287,5 @@ monthlyreturns.verifiedStatusDeclaration.error.required = Dewiswch ‘Iawn’ os
 monthlyreturns.verifiedStatusDeclaration.checkYourAnswersLabel = Datganiad o’r statws dilysu
 monthlyreturns.employmentStatusDeclaration.checkYourAnswersLabel = Datganiad o’r statws cyflogaeth
 
-verifySubcontractors.warningIcon = Warning
 
-monthlyreturns.verifiedStatusDeclaration.change.hidden = Verified Status Declaration
-monthlyreturns.verifiedStatusDeclaration.legend = Has every subcontractor included on this return either been verified with HM Revenue & Customs, or been included in previous CIS returns in this, or the previous two tax years?
-monthlyreturns.employmentStatusDeclaration.legend = Has the employment status of each individual included on this return been considered and have payments not been made under contracts of employment?
-monthlyreturns.employmentStatusDeclaration.change.hidden = EmploymentStatusDeclaration
-monthlyreturns.summarySubcontractorPayments.intro = You have added the payment details of {0} subcontractors.
-verifySubcontractors.error.required = Select yes if you want to verify your subcontractors now
-monthlyreturns.selectSubcontractors.noSubcontractors = No subcontractors have been added yet
-monthlyreturns.selectSubcontractors.includeThisMonth.accessibleLabel = Include {0}
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -318,7 +318,4 @@ monthlyreturns.summarySubcontractorPayments.intro = You have added the payment d
 verifySubcontractors.error.required = Select yes if you want to verify your subcontractors now
 monthlyreturns.selectSubcontractors.noSubcontractors = No subcontractors have been added yet
 monthlyreturns.selectSubcontractors.includeThisMonth.accessibleLabel = Include {0}
-monthlyreturns.subcontractorDetailsAdded.add.hidden = Add payment details for {0}s
-monthlyreturns.subcontractorDetailsAdded.amend.hidden = Amend payment details for {0}
-
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -190,7 +190,7 @@ monthlyreturns.declaration.listItem2 = the information provided in this return i
 monthlyreturns.declaration.warning = If you give any false information, you may face financial penalties and prosecution.
 monthlyreturns.declaration.submit = Confirm and continue
 
-monthlyreturns.submissionSending.title = Submission - Sending
+monthlyreturns.submissionSending.title = Your submission is being sent to HMRC
 monthlyreturns.submissionSending.h1 = Your submission is being sent to HMRC
 monthlyreturns.submissionSending.paragraph = Do not refresh this page or press the back button while your submission is being processed.
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -374,7 +374,7 @@ monthlyreturns.totalTaxDeducted.error.required = Enter the total tax deducted
 
 verifySubcontractors.title = You have unverified subcontractors
 verifySubcontractors.heading = You have unverified subcontractors
-verifySubcontractors.WarningIcon = Warning
+verifySubcontractors.warningIcon = Warning
 verifySubcontractors.warningText = One or more subcontractors have not been verified. Not verifying subcontractors will result in them receiving a higher rate of tax.
 verifySubcontractors.P1 = Do you want to verify your subcontractors now?
 verifySubcontractors.yes = Yes


### PR DESCRIPTION
This PR contains updates for the Welsh translation of the Returns journey.

- Updated the submission sending screen page title and heading to align with the Confluence content, as the English version differs. This update has been included as part of this ticket following discussion with Moin. 

- Updated the key verifySubcontractors.warningIcon in the English version to correctly update the value